### PR TITLE
Adds `theme create` command

### DIFF
--- a/src/cli/shopkeeper-theme-create.ts
+++ b/src/cli/shopkeeper-theme-create.ts
@@ -1,15 +1,34 @@
-#!/usr/bin/env node
-
 import { Command } from 'commander';
+import themekit from '@shopify/themekit'
+import ShopifyClient from '../lib/shopify-client';
 
 const program = new Command();
 
 program
   .description('creates a new theme from the current working directory')
-  .option('-n, --name', 'name of the theme you want created')
+  .option('-n, --name <theme-name>', 'name of the theme you want created')
 
-program.action(() => {
-  console.log("create a theme")
+program.action(async (options) => {
+  const storeUrl = `https://${process.env.PROD_STORE_URL}` || "";
+  const storePassword = process.env.PROD_PASSWORD || "";
+
+  const client = new ShopifyClient(storeUrl, storePassword)
+
+  const themes = await client.getThemes()
+  const duplicateThemes = themes.filter(({ name }: { name: string }) => name === options.name)
+  if (duplicateThemes.length > 0) {
+    throw new Error(`The theme ${options.name} already exists in this store.`)
+  }
+
+  const { theme } = await client.createTheme(options.name)
+  await themekit.command('deploy', {
+    store: storeUrl,
+    password: storePassword,
+    themeid: theme.id,
+    dir: 'shopify'
+  })
+
+  console.log(`Preview ready at ${storeUrl}?preview_theme_id=${theme.id}`)
 });
 
 program.parse();

--- a/src/lib/shopify-client.ts
+++ b/src/lib/shopify-client.ts
@@ -1,5 +1,13 @@
 import axios, { AxiosInstance } from 'axios';
 
+interface CreateThemePayload {
+  theme: {
+    name: string,
+    src?: string,
+    role?: string
+  }
+}
+
 export default class ShopifyClient {
   API_VERSION: string = '2021-04';
   PUBLISHED: string = 'main';
@@ -33,12 +41,29 @@ export default class ShopifyClient {
     return response.data;
   }
 
+  async createTheme(name: string): Promise<any> {
+    try {
+      const { data } = await this.create(this.themesPath(), {
+        theme: { name }
+      })
+
+      return data
+    } catch(error) {
+      console.log(error)
+    }
+  }
+
   private themesPath(): string {
     return `/admin/api/${this.API_VERSION}/themes.json`
   }
 
   private themePath(id: string): string {
     return `/admin/api/${this.API_VERSION}/themes/${id}.json`
+  }
+
+
+  private async create(path: string, payload: CreateThemePayload) {
+    return await this.axiosClient().post(path, payload);
   }
 
   private async get(path: string) {


### PR DESCRIPTION
This PR adds the theme command `create` to create a new shopify theme and deploy the CWD into that theme.
This is a first pass at the create command outlined from the README. There are things we can definitely decouple / separate into a variable/config but I thought we'd leave it as is for now since that would require refactoring in other parts of the codebase as well.


**CREATE**
We first grab a list of all the themes from the store to check for any duplicated theme names. This is important to prevent any collisions when working with theme names since Shopify does not error duplicate theme names by default. 

We use [shopify's admin api](https://shopify.dev/docs/admin-api/rest/reference/online-store/theme#create-2021-01) to create our theme instead of [themekit](https://shopify.dev/tools/theme-kit/command-reference#new) because themekit takes an additional step to deploy a default theme template into the newly created theme + themekit doesn't return the theme object from the promise.

Finally we deploy to the newly created theme and log a preview link.