### PR TITLE
Bump version to 0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thebeyondgroup/shopkeeper",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thebeyondgroup/shopkeeper",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@shopify/themekit": "^1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thebeyondgroup/shopkeeper",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A CLI for managing Shopify stores",
   "main": "dist/src/shopkeeper.js",
   "types": "dist/src/shopkeeper.d.ts",


### PR DESCRIPTION
Update version number to 0.0.8

Changes:
* New `theme get-id` command
* Updated node-themekit version to give the latest version of the themekit binary