### PR TITLE
Add options to get published and on-deck theme id 

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,13 +1,13 @@
 # Shopkeeper CLI
 
-This is a description of the commands provided by `shopkeeper `. 
+This is a description of the commands provided by `shopkeeper `.
 
 ## Philosophy
 
 Shopkeeper is inspired by [`hub`](https://github.com/github/hub), which augments
 `git` with GitHub specific functionality.
 
-We are working towards a CLI that will allow you to use Shopkeeper as your 
+We are working towards a CLI that will allow you to use Shopkeeper as your
 primary tool for interacting with Shopify themes.
 
 Shopkeeper's approach and commands embody the approach we at The Beyond Group
@@ -140,6 +140,10 @@ shopkeeper theme get-id --name "author/feature-branch-name"
 ```
 Called with the flag `--name`, this command returns the id of the theme. If a theme
 with the passed name cannot be found, this command fails with status code 1.
+
+Called with the flag `--published`, this command returns the id of the published theme.
+
+Called with the flag `--on-deck`, this command returns the id of the ondeck theme.
 
 ### `themekit`
 

--- a/src/cli/shopkeeper-theme-get-id.ts
+++ b/src/cli/shopkeeper-theme-get-id.ts
@@ -4,27 +4,54 @@ import ShopifyClient from '../lib/shopify-client';
 const program = new Command();
 
 program
-  .description('gets the id for the passsed name')
-  .option('-n, --name <theme-name>', 'name of the theme you want created')
+  .description('gets any theme id, based on options')
+  .option('-n, --name <theme-name>', 'gets the theme id for the passsed name')
+  .option('-p, --published', 'gets the published theme id')
+  .option('-o, --on-deck', 'gets the ondeck theme id')
 
 program.action(async (options) => {
   const storeUrl = `https://${process.env.PROD_STORE_URL}` || "";
   const storePassword = process.env.PROD_PASSWORD || "";
 
-  const client = new ShopifyClient(storeUrl, storePassword)
-  
-  try{
-    const theme = await client.getThemeByName(options.name)
-    if(theme){
-     const { id } = theme
-     console.log(id)
-    }else{
-      console.log(`${options.name} does not exist on ${storeUrl}`)
-      process.exit(1)
-    }
-  }catch(error){
-    console.log(error)
-    process.exit(1)
+  const client = new ShopifyClient(storeUrl, storePassword);
+  const firstOption = Object.keys(program.opts())[0];
+
+  switch (firstOption) {
+    case 'onDeck':
+      try{
+        const ondeckId = await client.getOndeckThemeId();
+        console.log(ondeckId);
+      }catch(error){
+        console.log(error);
+        process.exit(1);
+      }
+      break;
+    case 'published':
+      try{
+        const publishedId = await client.getPublishedThemeId();
+        console.log(publishedId);
+      }catch(error){
+        console.log(error);
+        process.exit(1);
+      }
+      break;
+    case 'name':
+      try{
+        const theme = await client.getThemeByName(options.name);
+        if(theme){
+         const { id } = theme;
+         console.log(id);
+        }else{
+          console.log(`${options.name} does not exist on ${storeUrl}`);
+          process.exit(1);
+        }
+      }catch(error){
+        console.log(error);
+        process.exit(1);
+      }
+      break;
+    default:
+      break;
   }
 });
 

--- a/src/lib/shopify-client.ts
+++ b/src/lib/shopify-client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import BlueGreenStrategy from './strategy/blue-green-strategy';
 
 type CreateThemePayload = {
   theme: {
@@ -47,12 +48,14 @@ export default class ShopifyClient {
   }
 
   async getPublishedThemeId(): Promise<any> {
-    try{
-      const publishedTheme = await this.getPublishedTheme()
-      return publishedTheme.id.toString()
-    }catch(error){
-      console.log(error)
-    }
+    const publishedTheme = await this.getPublishedTheme()
+    return publishedTheme.id.toString()
+  }
+
+  async getOndeckThemeId(): Promise<any> {
+    const blueGreenStrategy = new BlueGreenStrategy();
+    const onDeckThemeId = await blueGreenStrategy.ondeckThemeId();
+    return onDeckThemeId;
   }
 
   async deleteTheme(id: string): Promise<any>{
@@ -75,7 +78,7 @@ export default class ShopifyClient {
     }catch(error){
       console.log(error)
     }
-    
+
   }
 
   async createTheme(name: string): Promise<any> {
@@ -94,7 +97,7 @@ export default class ShopifyClient {
 
   async updateTheme(themeId: string, name: string): Promise<any>{
     try{
-      const { data }  = await this.update(this.themePath(themeId), { 
+      const { data }  = await this.update(this.themePath(themeId), {
         theme: { name: name }
       });
 

--- a/src/lib/strategy/blue-green-strategy.ts
+++ b/src/lib/strategy/blue-green-strategy.ts
@@ -9,18 +9,28 @@ export default class BlueGreenStrategy implements Strategy {
   async deploy(staging: boolean = false){
     const theme = await this.publishedTheme();
     const themeId = theme.id.toString();
-    
+
     await this.downloadPublishedThemeSettings();
-    
+
     // determine destination blue or green
     const onDeckTheme = this.ondeckTheme(themeId);
-    
+
     // deploy to destination
     console.log(`Deploying to ${onDeckTheme}`)
     await this.deployEnvironment(onDeckTheme);
 
     if(staging){
       await this.deployEnvironment(this.STAGING);
+    }
+  }
+
+  async ondeckThemeId() {
+    const theme = await this.publishedTheme();
+    const publishedThemeId = theme.id.toString();
+    if(this.isBlueTheme(publishedThemeId)){
+      return process.env.PROD_GREEN_THEME_ID;
+    }else{
+      return process.env.PROD_BLUE_THEME_ID;
     }
   }
 


### PR DESCRIPTION
Adds two options to the `theme get-id` command
- --published (returns the published theme id)
- --on-deck (returns the ondeck theme id)