### PR TITLE
Release 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thebeyondgroup/shopkeeper",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thebeyondgroup/shopkeeper",
-      "version": "0.0.9",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@shopify/themekit": "^1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thebeyondgroup/shopkeeper",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "A CLI for managing Shopify stores",
   "main": "dist/src/shopkeeper.js",
   "types": "dist/src/shopkeeper.d.ts",


### PR DESCRIPTION
Let's bump up the version number to 0.1.0 because the API is stabilizing.