### PR TITLE
Publish package to GitHub and npm registries

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+@thebeyondgroup:registry=https://npm.pkg.github.com
+
+//npm.pkg.github.com/:_authToken=${AUTH_TOKEN}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -r ./dist",
     "shopkeeper": "./dist/src/cli/shopkeeper.js",
     "test": "jest",
+    "postpublish": "npm publish --ignore-scripts --@thebeyondgroup:registry='https://registry.npmjs.org'",
     "prepublishOnly": "./build.sh"
   },
   "bin": {


### PR DESCRIPTION
We need the `.npmrc` to point to github so it's published there. We use the `postpublish` to publish to the npm registry.