### PR TITLE
Add Online Store 2.0 JSON template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,78 @@ Shopkeeper is a CLI for managing Shopify stores.
 
 For usage instructions, see the [command specification](docs/cli.md).
 
+## Usage
+
+Shopkeeper makes it easy to manage multiple Shopify stores from a single codebase.
+In particular, it makes it easy to change the environment and manage theme settings.
+
+Add a `.shopkeeper` folder to the root of your project to store your environments.
+For example, here we introduce a `production` environment that refers to a particular a production Shopify instance. In multi-store, multi-region setups, you might have a directory for each region. Say `canada`, `united-states`, or `united-kingdom`.
+
+```
+.shopkeeper
+├── production
+│   ├── config
+│   │   └── settings_data.json
+│   ├── env
+│   ├── env.sample
+│   └── templates
+│       ├── index.json
+│       └── page.about-us.json
+└── settings.yml
+```
+
+Each folder contains theme settings stored in their corresponding `config` and `templates` folders. It also contains a `env` file that's copied to the project root
+as `.env ` when the environment is switched.
+
+Shopkeeper depends on the following environment variables being set:
+
+| Name | Use |
+|----|-----|
+|`PROD_STORE_URL`| `<store-name>`.myshopify.com |
+|`PROD_PASSWORD`| Shopify private app password |
+|`STAGING_THEME_ID`| theme id to use for the staging theme |
+|`PROD_BLUE_THEME_ID`| theme id to use for the blue theme |
+|`PROD_GREEN_THEME_ID`| theme id to use for the green theme |
+
+We recommend setting up your ThemeKit `config.yml` to use environment variables set in the `.env` and loaded into the shell context using something like [direnv](https://direnv.net/). The following `config.yml` shows how the file can be setup to support the blue/green deployment strategy Shopkeeper employs.
+
+```
+# config.yml
+development:
+  password: ${DEV_PASSWORD}
+  theme_id: ${DEV_THEME_ID}
+  store: ${PROD_STORE_URL}
+  directory: shopify
+staging:
+  password: ${PROD_PASSWORD}
+  theme_id: ${STAGING_THEME_ID}
+  store: ${PROD_STORE_URL}
+  directory: shopify
+production-blue:
+  password: ${PROD_PASSWORD}
+  theme_id: ${PROD_BLUE_THEME_ID}
+  store: ${PROD_STORE_URL}
+  directory: shopify
+production-green:
+  password: ${PROD_PASSWORD}
+  theme_id: ${PROD_GREEN_THEME_ID}
+  store: ${PROD_STORE_URL}
+  directory: shopify
+```
+
+Use `settings.yml` to customize the name of your theme.
+
+```
+productionThemeName: "Your Name Production - " "Defaults to Production"
+stagingThemeName: "Your Name Staging" # Defaults to "Staging"
+themeDirectory: "dist" # Defaults to "shopify"; relative to your project directory
+```
+
+The `productionThemeName` is used as a prefix for the blue and green themes. It will 
+turn into `Your Name Production - Blue`. Also, on each deploy the current git SHA will
+be prepended `[abc1234]Your Name Production - Blue`
+
 ## Development
 
 To install this package globally while you're working on it:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,16 +88,16 @@ Called without flags, this command uploads the settings from the theme in the cu
 shopkeeper settings save us
 ```
 Called without flags and with the argument `<store-name>`, this command copies
-the theme settings in `shopify/config` to
-`.shopkeeper/<store-name>/settings_data.json`.
+the theme settings in `shopify/config` to `.shopkeeper/<store-name>/config/settings_data.json` and
+`shopify/templates/*.json` to `.shopkeeper/<store-name>/templates/*.json`.
 
 **`shopkeeper settings restore`**
 
 ```
 shopkeeper settings restore us
 ```
-Called without flags and with the argument `<store-name>`, this command copies the file from `.shopkeeper/<store-name>/settings_data.json`
-to `shopify/config/settings_data.json`.
+Called without flags and with the argument `<store-name>`, this command copies the file from `.shopkeeper/<store-name>/config/settings_data.json`
+to `shopify/config/settings_data.json` and `.shopkeeper/<store-name>/templates/*.json` to `shopify/templates/*.json`.
 
 
 **`shopkeeper settings sync` (FUTURE)**
@@ -179,9 +179,10 @@ shopkeeper store switch us
 ```
 
 Called with the argument `<store-name>`, this command switches the .env file to
-the values provided in the corresponding `.shopkeeper/<store-name>/env`. It also 
-copies the settings file in `.shopkeeper/<store-name>/settings_data.json` to 
-`shopify/config/settings_data.json`.
+the values provided in the corresponding `.shopkeeper/<store-name>/env`. It 
+copies the settings file in `.shopkeeper/<store-name>/config/settings_data.json` to 
+`shopify/config/settings_data.json` and `.shopkeeper/<store-name>/templates/*.json` to
+`shopify/templates/*.json`.
 
 ### Store Current
 **`shopkeeper store current`**

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^0.21.1",
         "commander": "^8.0.0",
         "fs-extra": "^10.0.0",
+        "glob": "^7.2.0",
         "head-hash": "^0.3.0",
         "inquirer": "^8.0.0",
         "string-env-interpolation": "^1.0.1",
@@ -24,6 +25,7 @@
         "shopkeeper": "dist/src/cli/shopkeeper.js"
       },
       "devDependencies": {
+        "@types/glob": "^7.2.0",
         "@types/jest": "^26.0.20",
         "@types/mock-fs": "^4.13.0",
         "@types/prettier": "^2.2.1",
@@ -982,6 +984,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1033,6 +1045,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "node_modules/@types/mock-fs": {
       "version": "4.13.0",
@@ -1423,8 +1441,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -1598,7 +1615,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2103,8 +2119,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -3131,8 +3146,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -3210,10 +3224,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3527,7 +3540,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4985,7 +4997,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5584,7 +5595,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8523,6 +8533,16 @@
         "@types/node": "*"
       }
     },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8574,6 +8594,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "@types/mock-fs": {
       "version": "4.13.0",
@@ -8870,8 +8896,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
@@ -9007,7 +9032,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9398,8 +9422,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "config-chain": {
       "version": "1.1.13",
@@ -10203,8 +10226,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -10257,10 +10279,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10494,7 +10515,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11615,7 +11635,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -12074,8 +12093,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "shopkeeper": "./dist/src/cli/shopkeeper.js"
   },
   "devDependencies": {
+    "@types/glob": "^7.2.0",
     "@types/jest": "^26.0.20",
     "@types/mock-fs": "^4.13.0",
     "@types/prettier": "^2.2.1",
@@ -38,6 +39,7 @@
     "axios": "^0.21.1",
     "commander": "^8.0.0",
     "fs-extra": "^10.0.0",
+    "glob": "^7.2.0",
     "head-hash": "^0.3.0",
     "inquirer": "^8.0.0",
     "string-env-interpolation": "^1.0.1",

--- a/src/cli/shopkeeper-store-switch.ts
+++ b/src/cli/shopkeeper-store-switch.ts
@@ -12,13 +12,17 @@ program.action(async(store) => {
   const config = new ShopkeeperConfig()
   const envSourcePath = config.storeEnvPath(store)
   const envDestinationPath = config.themeEnvPath
-  const settingsSourcePath = config.storeThemeSettingsPath(store)
 
   try {
-    const settingsDestinationPath = await config.themeSettingsPath()
-    await fs.copy(envSourcePath, envDestinationPath)
-    await fs.copy(settingsSourcePath, settingsDestinationPath)
+    const filesMoves = await config.storeThemeSettingsRestoreMoves(store)
+    filesMoves.push({ source: envSourcePath, destination: envDestinationPath })
+    filesMoves.forEach(async ({source, destination}) => {
+      await fs.copy(source, destination)
+      console.log(`Copied ${source} to ${destination}`)
+    })
+    
     await config.setCurrentStore(store)
+
     console.log(`Switched to ${store} environment`)
   } catch (err) {
     console.log(err)

--- a/src/cli/shopkeeper-store-switch.ts
+++ b/src/cli/shopkeeper-store-switch.ts
@@ -10,7 +10,7 @@ program
 
 program.action(async(store) => {
   const config = new ShopkeeperConfig()
-  const envSourcePath = config.storeEnvPath(store)
+  const envSourcePath = config.backupEnvPath(store)
   const envDestinationPath = config.themeEnvPath
 
   try {

--- a/src/cli/shopkeeper-store-switch.ts
+++ b/src/cli/shopkeeper-store-switch.ts
@@ -14,7 +14,7 @@ program.action(async(store) => {
   const envDestinationPath = config.themeEnvPath
 
   try {
-    const filesMoves = await config.storeThemeSettingsRestoreMoves(store)
+    const filesMoves = await config.backupThemeSettingsRestoreFileMoves(store)
     filesMoves.push({ source: envSourcePath, destination: envDestinationPath })
     filesMoves.forEach(async ({source, destination}) => {
       await fs.copy(source, destination)

--- a/src/cli/shopkeeper-theme-settings-restore.ts
+++ b/src/cli/shopkeeper-theme-settings-restore.ts
@@ -16,11 +16,12 @@ program.action(async(store) => {
     storeToRestore = await config.getCurrentStore()
   }
 
-  const settingsSourcePath = config.storeThemeSettingsPath(storeToRestore)
-
   try {
-    const settingsDestinationPath = await config.themeSettingsPath()
-    await fs.copy(settingsSourcePath, settingsDestinationPath)
+    const fileMoves = await config.storeThemeSettingsRestoreMoves(storeToRestore)
+    fileMoves.forEach(async ({source, destination}) => {
+      await fs.copy(source, destination)
+      console.log(`Copied ${source} to ${destination}`)
+    })
     console.log(`Restored settings for ${storeToRestore}.`)
   } catch (err) {
     console.log(err)

--- a/src/cli/shopkeeper-theme-settings-restore.ts
+++ b/src/cli/shopkeeper-theme-settings-restore.ts
@@ -17,7 +17,7 @@ program.action(async(store) => {
   }
 
   try {
-    const fileMoves = await config.storeThemeSettingsRestoreMoves(storeToRestore)
+    const fileMoves = await config.backupThemeSettingsRestoreFileMoves(storeToRestore)
     fileMoves.forEach(async ({source, destination}) => {
       await fs.copy(source, destination)
       console.log(`Copied ${source} to ${destination}`)

--- a/src/cli/shopkeeper-theme-settings-restore.ts
+++ b/src/cli/shopkeeper-theme-settings-restore.ts
@@ -25,6 +25,7 @@ program.action(async(store) => {
     console.log(`Restored settings for ${storeToRestore}.`)
   } catch (err) {
     console.log(err)
+    process.exit(1)
   }
 })
 

--- a/src/cli/shopkeeper-theme-settings-save.ts
+++ b/src/cli/shopkeeper-theme-settings-save.ts
@@ -17,7 +17,7 @@ program.action(async(store) => {
   }
 
   try {
-    const fileMoves = await config.storeThemeSettingsSaveMoves(storeToRestore)
+    const fileMoves = await config.backupThemeSettingsSaveFileMoves(storeToRestore)
     fileMoves.forEach(async ({source, destination}) => {
       await fs.copy(source, destination)
       console.log(`Copied ${source} to ${destination}`)

--- a/src/cli/shopkeeper-theme-settings-save.ts
+++ b/src/cli/shopkeeper-theme-settings-save.ts
@@ -16,11 +16,12 @@ program.action(async(store) => {
     storeToRestore = await config.getCurrentStore()
   }
 
-  const settingsDestinationPath = config.storeThemeSettingsPath(storeToRestore)
-
   try {
-    const settingsSourcePath = await config.themeSettingsPath()
-    await fs.copy(settingsSourcePath, settingsDestinationPath)
+    const fileMoves = await config.storeThemeSettingsSaveMoves(storeToRestore)
+    fileMoves.forEach(async ({source, destination}) => {
+      await fs.copy(source, destination)
+      console.log(`Copied ${source} to ${destination}`)
+    })
     console.log(`Saved settings for ${storeToRestore}.`)
   } catch (err) {
     console.log(err)

--- a/src/lib/deploy-strategy/blue-green-strategy.ts
+++ b/src/lib/deploy-strategy/blue-green-strategy.ts
@@ -37,6 +37,7 @@ export default class BlueGreenStrategy implements DeployStrategy {
   private async updateThemeNameWithCommitHash(themeId: string, newName: string): Promise<any>{
     console.log(`Renaming theme to ${newName}`)
     await this.shopifyClient().updateTheme(themeId, newName)
+    console.log(`Finished renaming theme to ${newName}`)
   }
 
   private async deployEnvironment(environment: string){

--- a/src/lib/shopkeeper-config.ts
+++ b/src/lib/shopkeeper-config.ts
@@ -75,7 +75,7 @@ export default class ShopkeeperConfig {
     return process.cwd() + `/${this.backupRootPath}/${store}/templates/${fileName}`
   }
 
-  async storeThemeSettingsSaveMoves(storeToRestore: string): Promise<Array<FileMove>>{
+  async backupThemeSettingsSaveFileMoves(storeToRestore: string): Promise<Array<FileMove>>{
     const settingsSourcePath = await this.themeSettingsPath()
     const settingsDestinationPath = this.backupThemeSettingsDataPath(storeToRestore)
     const fileMoves = [ 
@@ -97,7 +97,7 @@ export default class ShopkeeperConfig {
     return fileMoves.concat(templateMoves)
   }
 
-  async storeThemeSettingsRestoreMoves(storeToRestore: string): Promise<Array<FileMove>>{
+  async backupThemeSettingsRestoreFileMoves(storeToRestore: string): Promise<Array<FileMove>>{
     const settingsSourcePath = this.backupThemeSettingsDataPath(storeToRestore)
     const settingsDestinationPath = await this.themeSettingsPath()
     const fileMoves = [

--- a/src/lib/shopkeeper-config.ts
+++ b/src/lib/shopkeeper-config.ts
@@ -46,12 +46,12 @@ export default class ShopkeeperConfig {
     return process.env.PROD_GREEN_THEME_ID || ''
   }
 
-  get rootPath(): string {
+  get backupRootPath(): string {
     return '.shopkeeper'
   }
 
   get currentStorePath(): string {
-    return process.cwd() + `/${this.rootPath}/${this.currentStoreFileName}`
+    return process.cwd() + `/${this.backupRootPath}/${this.currentStoreFileName}`
   }
 
   get currentStoreFileName(): string {
@@ -59,7 +59,7 @@ export default class ShopkeeperConfig {
   }
 
   get settingsPath(): string {
-    return `${this.rootPath}/settings.yml`
+    return `${this.backupRootPath}/settings.yml`
   }
 
   async themeSettingsPath(): Promise<string>{
@@ -68,11 +68,11 @@ export default class ShopkeeperConfig {
   }
 
   backupThemeSettingsDataPath(store: string): string {
-    return process.cwd() + `/${this.rootPath}/${store}/config/settings_data.json`
+    return process.cwd() + `/${this.backupRootPath}/${store}/config/settings_data.json`
   }
 
   backupThemeSettingsTemplatesPath(store: string, fileName: string): string {
-    return process.cwd() + `/${this.rootPath}/${store}/templates/${fileName}`
+    return process.cwd() + `/${this.backupRootPath}/${store}/templates/${fileName}`
   }
 
   async storeThemeSettingsSaveMoves(storeToRestore: string): Promise<Array<FileMove>>{
@@ -108,7 +108,7 @@ export default class ShopkeeperConfig {
     ]
 
     const themeDir = await this.themeDirectory()
-    const jsonTemplateFiles = glob.sync(`${this.rootPath}/${storeToRestore}/templates/**/*.json`)
+    const jsonTemplateFiles = glob.sync(`${this.backupRootPath}/${storeToRestore}/templates/**/*.json`)
     const templateMoves = jsonTemplateFiles.map(fileName => {
       const baseName = fileName.split("/").pop() || ""
       return {
@@ -124,8 +124,7 @@ export default class ShopkeeperConfig {
     return process.cwd() + "/.env"
   }
 
-  storeEnvPath(store: string): string {
-    return process.cwd() + `/${this.rootPath}/${store}/env`;
+    return process.cwd() + `/${this.backupRootPath}/${store}/env`;
   }
 
   async getCurrentStore(): Promise<any>{

--- a/src/lib/shopkeeper-config.ts
+++ b/src/lib/shopkeeper-config.ts
@@ -60,8 +60,14 @@ export default class ShopkeeperConfig {
     return process.cwd() + `/${themeDir}/config/settings_data.json`
   }
 
-  storeThemeSettingsPath(store: string): string {
-    return process.cwd() + `/${this.rootPath}/${store}/settings_data.json`
+  backupThemeSettingsDataPath(store: string): string {
+    return process.cwd() + `/${this.rootPath}/${store}/config/settings_data.json`
+  }
+
+  backupThemeSettingsTemplatesPath(store: string, fileName: string): string {
+    return process.cwd() + `/${this.rootPath}/${store}/templates/${fileName}`
+  }
+
   }
 
   get themeEnvPath(): string {

--- a/src/lib/shopkeeper-config.ts
+++ b/src/lib/shopkeeper-config.ts
@@ -124,6 +124,7 @@ export default class ShopkeeperConfig {
     return process.cwd() + "/.env"
   }
 
+  backupEnvPath(store: string): string {
     return process.cwd() + `/${this.backupRootPath}/${store}/env`;
   }
 
@@ -142,6 +143,7 @@ export default class ShopkeeperConfig {
 
     return `[${hash}] ${settings.stagingThemeName}`
   }
+
   async productionThemeName(): Promise<string> {
     const settings = await this.getSettings()
     const hash = await this.gitHeadHash()

--- a/src/shopkeeper.ts
+++ b/src/shopkeeper.ts
@@ -1,12 +1,18 @@
 // This is the main entry point to all the shopkeeper functionality
 // This is also the class to import when using shopkeeper elsewhere.
 import themeKit from '@shopify/themekit';
+import glob from 'glob';
 
 export default class Shopkeeper {
   options: any;
   
   constructor(options: any) {
     this.options = options;
+  }
+
+  themeJSONTemplateFiles(){
+    return glob.sync("shopify/templates/**/*.json")
+      .map(fileName => fileName.replace("shopify/", ""))
   }
 
   async settingsDownload() {

--- a/src/shopkeeper.ts
+++ b/src/shopkeeper.ts
@@ -17,7 +17,10 @@ export default class Shopkeeper {
 
   async settingsDownload() {
     const flags: {[k: string]: any} = {
-      files: ['config/settings_data.json']
+      files: [
+        'config/settings_data.json',
+        ...this.themeJSONTemplateFiles()
+      ]
     };
   
     if (this.options.env) {
@@ -41,7 +44,10 @@ export default class Shopkeeper {
 
   async settingsUpload() {
     const flags: {[k: string]: any} = {
-      files: ['config/settings_data.json']
+      files: [
+        'config/settings_data.json',
+        ...this.themeJSONTemplateFiles()
+      ]
     };
   
     // TODO: Need to add credentials
@@ -58,5 +64,4 @@ export default class Shopkeeper {
 
     await themeKit.command('deploy', flags);
   }
-
 }


### PR DESCRIPTION
In this PR, I modify the `theme settings restore`, `theme settings save`, and `store switch` commands to handle JSON templates. This change also affects the `theme deploy` command as it needs to know which theme settings files to request from the published theme.

With the introduction of JSON templates, each JSON template is now a settings file. This means we need to consider `config/settings_data.json` and `templates/*.json` when we're saving and restoring the settings.

**Behaviour**
* `theme settings saves` copies all `*.json` files from `<theme root>/templates` to `.shopkeeper/templates`
* `theme settings restore` copies all `*.json` files from `.shopkeeper/templates` to `<theme root>/templates`
* `store switch` does the same as `settings restore`
* `theme deploy` uses `<theme root>/templates` as the source of truth for requesting theme files.

> ⚠️ With this change, you need to ensure there are `*.json` files in your `<theme root>/template` directory. You can do this by running restore for the desired environment before running deploy.