### PR TITLE
Add better support for Online Store 2.0 themes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ primary tool for interacting with Shopify themes.
 
 Shopkeeper's approach and commands embody the approach we at [The Beyond
 Group](https://thebeyondgroup.la) use to build and deploy themes. You might want
-to do something in a different way than us and we're open to extensions that
+to do something in a different way than united-states and we're open to extensions that
 extend and enhance our defaults. Open a PR!
 
 Also, like all software, there are refinements that can be done to this CLI.
@@ -70,37 +70,60 @@ If blue is published, it publishes green. If green is published, it publishes
 blue. Before publishing, the theme settings from the published theme are copied
 to the rollback theme.
 
-**`shopkeeper settings download`**
+**`shopkeeper theme settings download`**
 
 ```
-shopkeeper settings download
+shopkeeper theme settings download
 ```
 Called without flags, this command downloads the settings from the store's published
 theme to the theme in the current working directory.
 
-**`shopkeeper settings upload`**
+**`shopkeeper theme settings upload`**
 
-Called without flags, this command uploads the settings from the theme in the current working directory.
+Called without flags, this command uploads the settings from the theme in the
+current working directory.
 
-**`shopkeeper settings save`**
-
-```
-shopkeeper settings save us
-```
-Called without flags and with the argument `<store-name>`, this command copies
-the theme settings in `shopify/config` to `.shopkeeper/<store-name>/config/settings_data.json` and
-`shopify/templates/*.json` to `.shopkeeper/<store-name>/templates/*.json`.
-
-**`shopkeeper settings restore`**
+**`shopkeeper theme settings save`**
 
 ```
-shopkeeper settings restore us
+shopkeeper theme settings save united-states
 ```
-Called without flags and with the argument `<store-name>`, this command copies the file from `.shopkeeper/<store-name>/config/settings_data.json`
-to `shopify/config/settings_data.json` and `.shopkeeper/<store-name>/templates/*.json` to `shopify/templates/*.json`.
+Called without flags and with the argument `<environment>`, this command copies
+the theme settings in `shopify/config` to
+`.shopkeeper/<environment>/config/settings_data.json` and
+`shopify/templates/*.json` to `.shopkeeper/<environment>/templates/*.json`. All
+`.shopkeeper/<environment>/templates/*.json` are replaced.
+
+```
+shopkeeper theme settings save united-states --copy
+```
+Called with the flag `-c` or `--copy` and with the argument `<environment>`,
+this command copies the theme settings in `shopify/config` to
+`.shopkeeper/<environment>/config/settings_data.json` and
+`shopify/templates/*.json` to `.shopkeeper/<environment>/templates/*.json`.
+
+**`shopkeeper theme settings restore`**
+
+```
+shopkeeper theme settings restore united-states
+```
+Called without flags and with the argument `<environment>`, this command copies
+the file from `.shopkeeper/<environment>/config/settings_data.json` to
+`shopify/config/settings_data.json` and
+`.shopkeeper/<environment>/templates/*.json` to `shopify/templates/*.json`. All
+`shopify/templates/*.json` are replaced.
+
+```
+shopkeeper theme settings restore united-states --copy
+```
+Called with the flag `-c` or `--copy` and with the argument `<environment>`,
+this command copies the file from
+`.shopkeeper/<environment>/config/settings_data.json` to
+`shopify/config/settings_data.json` and
+`.shopkeeper/<environment>/templates/*.json` to `shopify/templates/*.json`
 
 
-**`shopkeeper settings sync` (FUTURE)**
+**`shopkeeper theme settings sync` (FUTURE)**
 
 ### Publish
 **`shopkeeper theme publish`**
@@ -175,13 +198,13 @@ Called with the flag `--on-deck`, this command returns the id of the on deck the
 Called without flags and args, this command fails with status code 1.
 
 ```
-shopkeeper store switch us
+shopkeeper store switch united-states
 ```
 
-Called with the argument `<store-name>`, this command switches the .env file to
-the values provided in the corresponding `.shopkeeper/<store-name>/env`. It 
-copies the settings file in `.shopkeeper/<store-name>/config/settings_data.json` to 
-`shopify/config/settings_data.json` and `.shopkeeper/<store-name>/templates/*.json` to
+Called with the argument `<environment>`, this command switches the .env file to
+the values provided in the corresponding `.shopkeeper/<environment>/env`. It 
+copies the settings file in `.shopkeeper/<environment>/config/settings_data.json` to 
+`shopify/config/settings_data.json` and `.shopkeeper/<environment>/templates/*.json` to
 `shopify/templates/*.json`.
 
 ### Store Current

--- a/src/cli/shopkeeper-store-current.ts
+++ b/src/cli/shopkeeper-store-current.ts
@@ -10,7 +10,7 @@ program.action(async () => {
   const config = new ShopkeeperConfig();
   
   try{
-    const currentStore = await config.getCurrentStore()
+    const currentStore = await config.getCurrentEnvironment()
     console.log(currentStore)
   }catch(err) {
     console.log(err)

--- a/src/cli/shopkeeper-store-switch.ts
+++ b/src/cli/shopkeeper-store-switch.ts
@@ -5,25 +5,40 @@ import ShopkeeperConfig from '../lib/shopkeeper-config';
 const program = new Command();
 
 program
-  .description("switch to the environment variables for a store")
-  .argument("<store>", "the name of the store environment")
+  .description("switch to environment's settings")
+  .argument("<environment>", "the environment")
+  .option(
+    '-c --copy', 
+    'preserve contents of theme when changing environments. By default, settings are replaced.',
+    false
+  )
 
-program.action(async(store) => {
+const options = program.opts();
+
+program.action(async(environment) => {
   const config = new ShopkeeperConfig()
-  const envSourcePath = config.backupEnvPath(store)
+  const envSourcePath = config.backupEnvPath(environment)
   const envDestinationPath = config.themeEnvPath
 
   try {
-    const filesMoves = await config.backupThemeSettingsRestoreFileMoves(store)
+    console.log(`Switching to ${environment}`)
+    // Remove all JSON files from shopify/templates
+    if(!options.copy) {
+      const themeJSONTemplates = await config.themeJSONTemplates()
+      themeJSONTemplates.forEach(fileName => {
+        fs.rm(fileName)
+        console.log(`Deleted ${fileName}`)
+      })
+    }
+
+    const filesMoves = await config.backupThemeSettingsRestoreFileMoves(environment)
     filesMoves.push({ source: envSourcePath, destination: envDestinationPath })
     filesMoves.forEach(async ({source, destination}) => {
       await fs.copy(source, destination)
       console.log(`Copied ${source} to ${destination}`)
     })
-    
-    await config.setCurrentStore(store)
 
-    console.log(`Switched to ${store} environment`)
+    await config.setCurrentEnvironment(environment)
   } catch (err) {
     console.log(err)
     process.exit(1)

--- a/src/cli/shopkeeper-theme-create.ts
+++ b/src/cli/shopkeeper-theme-create.ts
@@ -1,5 +1,6 @@
 import themekit from '@shopify/themekit';
 import { Command } from 'commander';
+import glob from 'glob';
 import ShopifyClient from '../lib/shopify-client';
 import ShopkeeperConfig from '../lib/shopkeeper-config';
 
@@ -29,6 +30,19 @@ program.action(async (options) => {
     }
   
     const themeDirectory = await config.themeDirectory()
+    const sectionFiles = glob.sync(`${themeDirectory}/sections/*.liquid`)
+      .map(fileName => fileName.replace(`${themeDirectory}/`, ""))
+    
+    console.log("Uploading sections")
+    await themekit.command('deploy', {
+      files: sectionFiles,
+      store: storeUrl,
+      password: storePassword,
+      themeid: themeId,
+      dir: themeDirectory
+    })
+
+    console.log("Upload complete theme")
     await themekit.command('deploy', {
       store: storeUrl,
       password: storePassword,

--- a/src/cli/shopkeeper-theme-settings-restore.ts
+++ b/src/cli/shopkeeper-theme-settings-restore.ts
@@ -5,24 +5,40 @@ import fs  from 'fs-extra';
 import ShopkeeperConfig from '../lib/shopkeeper-config';
 
 program
-  .description("restore store theme settings")
-  .argument("[store]", "the name of the store environment")
+  .description("restore environment's settings")
+  .argument("<environment>", "the environment")
+  .option(
+    '-c --copy', 
+    'preserve contents of theme when restoring settings. By default, settings are replaced.',
+    false
+  )
 
-program.action(async(store) => {
+const options = program.opts();
+
+program.action(async(environment) => {
   const config = new ShopkeeperConfig();
-  let storeToRestore = store
+  let backupEnv = environment
 
-  if(!storeToRestore){
-    storeToRestore = await config.getCurrentStore()
+  if(!backupEnv){
+    backupEnv = await config.getCurrentEnvironment()
   }
 
   try {
-    const fileMoves = await config.backupThemeSettingsRestoreFileMoves(storeToRestore)
+    console.log(`Restoring settings for ${backupEnv}.`)
+    // Remove all JSON files from shopify/templates
+    if(!options.copy) {
+      const themeJSONTemplates = await config.themeJSONTemplates()
+      themeJSONTemplates.forEach(fileName => {
+        fs.rm(fileName)
+        console.log(`Deleted ${fileName}`)
+      })
+    }
+
+    const fileMoves = await config.backupThemeSettingsRestoreFileMoves(backupEnv)
     fileMoves.forEach(async ({source, destination}) => {
       await fs.copy(source, destination)
       console.log(`Copied ${source} to ${destination}`)
     })
-    console.log(`Restored settings for ${storeToRestore}.`)
   } catch (err) {
     console.log(err)
     process.exit(1)

--- a/src/cli/shopkeeper-theme-settings.ts
+++ b/src/cli/shopkeeper-theme-settings.ts
@@ -6,8 +6,8 @@ const program = new Command();
 
 program
   .command('download', 'download theme settings')
-  .command('save', 'save theme settings to shopkeeper cache')
-  .command('restore', 'restore theme settings from shopkeeper cache')
+  .command('save', 'save theme settings to environment')
+  .command('restore', 'restore theme settings from environment')
   // .command('upload', 'upload theme settings')
 
 program.action(() => {


### PR DESCRIPTION
**`store switch`, `theme settings save`, and `theme settings restore`**

In this PR, I change the default behaviour of these commands so that they replace the files at their destination. If files are not found in the source, they are removed in the destination. The `--copy` flag can be used to preserve the destination directory.

In addition, we modify the deploy process to upload sections first and then attempt a full upload. The sections will be skipped because of the checksum checks performed by ThemeKit.


