### PR TITLE
Pass glob argument for JSON templates to ThemeKit

### DIFF
--- a/src/lib/deploy-strategy/blue-green-strategy.ts
+++ b/src/lib/deploy-strategy/blue-green-strategy.ts
@@ -64,13 +64,11 @@ export default class BlueGreenStrategy implements DeployStrategy {
 
   private async downloadPublishedThemeSettings(environment: string){
     console.log(`Downloading settings from published theme`)
-    const themeDirectory = await this.themeDirectory()
-    const jsonTemplateFiles = glob.sync(`${themeDirectory}/templates/**/*.json`)
-      .map(fileName => fileName.replace(`${themeDirectory}/`, ""))
     
     const flags = {
-      files: ['config/settings_data.json',
-        ...jsonTemplateFiles
+      files: [
+        'config/settings_data.json',
+        'templates/*.json'
       ],
       env: environment,
       store: this.storeUrl,

--- a/src/shopkeeper.ts
+++ b/src/shopkeeper.ts
@@ -1,7 +1,6 @@
 // This is the main entry point to all the shopkeeper functionality
 // This is also the class to import when using shopkeeper elsewhere.
 import themeKit from '@shopify/themekit';
-import glob from 'glob';
 
 export default class Shopkeeper {
   options: any;
@@ -10,16 +9,11 @@ export default class Shopkeeper {
     this.options = options;
   }
 
-  themeJSONTemplateFiles(){
-    return glob.sync("shopify/templates/**/*.json")
-      .map(fileName => fileName.replace("shopify/", ""))
-  }
-
   async settingsDownload() {
     const flags: {[k: string]: any} = {
       files: [
         'config/settings_data.json',
-        ...this.themeJSONTemplateFiles()
+        "templates/*.json"
       ]
     };
   
@@ -46,7 +40,7 @@ export default class Shopkeeper {
     const flags: {[k: string]: any} = {
       files: [
         'config/settings_data.json',
-        ...this.themeJSONTemplateFiles()
+        "templates/*.json"
       ]
     };
   


### PR DESCRIPTION
Some source diving has revealed that ThemeKit supports glob patterns as arguments to the download command. This PR switches to using the glob instead of using the shopkeeper store as the source of truth.

This change will prevent templates created in the customizer from being missed.