### PR TITLE
Udpate Shopify package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@oclif/core": "2.8.11",
     "@oclif/plugin-commands": "2.2.17",
     "@oclif/plugin-help": "5.2.1",
-    "@shopify/cli": "3.48.0",
-    "@shopify/cli-kit": "3.48.0",
-    "@shopify/theme": "3.48.0",
+    "@shopify/cli": "3.48.1",
+    "@shopify/cli-kit": "3.48.1",
+    "@shopify/theme": "3.48.1",
     "fs-extra": "^11.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,10 +979,10 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@shopify/cli-kit@3.48.0":
-  version "3.48.0"
-  resolved "https://registry.yarnpkg.com/@shopify/cli-kit/-/cli-kit-3.48.0.tgz#2c0d1280ccd618d8cff3123b48690ec6578c5290"
-  integrity sha512-UQ1gmtQluS42UpVPJCyxNRi+v8pXICXJLGAm/v95NCQAjy6XWsf7AhyrfABlnXOc7ajKxmF2G1DFaswHoIGQVQ==
+"@shopify/cli-kit@3.48.1":
+  version "3.48.1"
+  resolved "https://registry.yarnpkg.com/@shopify/cli-kit/-/cli-kit-3.48.1.tgz#afa4f092a885d927d6f934b69ad789673857ae89"
+  integrity sha512-tRplafTFt7x/VOorC+YuM+Eeb0xfeg6vQ4z7S4gElpOLG+dtGHmbK3qQ3DiUznuEtWXK1xOnnBHjVYCqBljeuA==
   dependencies:
     "@bugsnag/js" "7.20.2"
     "@iarna/toml" "2.2.5"
@@ -991,6 +991,7 @@
     abort-controller "3.0.0"
     ansi-escapes "6.2.0"
     archiver "5.3.1"
+    bottleneck "2.19.5"
     chalk "5.3.0"
     change-case "4.1.2"
     color-json "3.0.5"
@@ -1043,35 +1044,35 @@
     unique-string "3.0.0"
     zod "3.21.4"
 
-"@shopify/cli@3.48.0":
-  version "3.48.0"
-  resolved "https://registry.yarnpkg.com/@shopify/cli/-/cli-3.48.0.tgz#7a4a3f66b279cc33529c727734a6c1ae5844f740"
-  integrity sha512-0YTvLfECeAoVAx73/EcdTadgbm1vnyebuVB4qgYhPHUnG/Z+FlXOO4Y7jPP6ifALzF2BLn/A01atVh4yYFnNzQ==
+"@shopify/cli@3.48.1":
+  version "3.48.1"
+  resolved "https://registry.yarnpkg.com/@shopify/cli/-/cli-3.48.1.tgz#96f0d58c0586185fb483b99e66bea335be464c0b"
+  integrity sha512-34qDZxhbKMSw9Dtil/QXBeHd0A3Ecm+6f8HyXycPvRJBwNuCaUO17LhPnsgfzohwd2NIYOo3EJP4FuHNTpv2+g==
   dependencies:
     "@oclif/core" "2.8.11"
     "@oclif/plugin-commands" "2.2.17"
     "@oclif/plugin-help" "5.2.11"
     "@oclif/plugin-plugins" "2.4.7"
-    "@shopify/cli-kit" "3.48.0"
-    "@shopify/plugin-did-you-mean" "3.48.0"
+    "@shopify/cli-kit" "3.48.1"
+    "@shopify/plugin-did-you-mean" "3.48.1"
     zod-to-json-schema "3.21.3"
 
-"@shopify/plugin-did-you-mean@3.48.0":
-  version "3.48.0"
-  resolved "https://registry.yarnpkg.com/@shopify/plugin-did-you-mean/-/plugin-did-you-mean-3.48.0.tgz#3c1132d76859a71d7d391a37ebd51b3c93f2deb3"
-  integrity sha512-SL/75M8cpoOQop857PfZQ5gJ3sF/cg4oMFaJQlLjVKM4P0ZFVS/0myj3WLzxVF3QQHzdf/h+yS+KnoC7dykBNw==
+"@shopify/plugin-did-you-mean@3.48.1":
+  version "3.48.1"
+  resolved "https://registry.yarnpkg.com/@shopify/plugin-did-you-mean/-/plugin-did-you-mean-3.48.1.tgz#5c5ca47a69b4586de6de2d5c278a8d3bd633feae"
+  integrity sha512-aYTw7YiEQ+VS/WBtgIJXM5aqaiG7XmHbt/QtsoG1gKnadetoOtatwtHLX4k6wYbZ2H5Q9yFpUG5wzgBwmRzxqQ==
   dependencies:
     "@oclif/core" "2.8.11"
-    "@shopify/cli-kit" "3.48.0"
+    "@shopify/cli-kit" "3.48.1"
     n-gram "2.0.2"
 
-"@shopify/theme@3.48.0":
-  version "3.48.0"
-  resolved "https://registry.yarnpkg.com/@shopify/theme/-/theme-3.48.0.tgz#780fde28cdddddb322e3f144718c00194cdd4bba"
-  integrity sha512-4wOr4OK4ec6pFy8TKhvZIbS6c803IcjbrZqbKXtFcGNWtyg8+MfxYtYuSX4qFnHmGXyT0ojQN89lHLALJJQ4/A==
+"@shopify/theme@3.48.1":
+  version "3.48.1"
+  resolved "https://registry.yarnpkg.com/@shopify/theme/-/theme-3.48.1.tgz#0e735d5978b663a778e017a04fe2a7675a793651"
+  integrity sha512-5yfq6Rn0wUu3XjcahUT6ksbPuUIhdxC60DIMp3/y4zJOiufNGekgfnHLIVWfIgE+wQFToX+hLo4oIYcT13smDg==
   dependencies:
     "@oclif/core" "2.8.11"
-    "@shopify/cli-kit" "3.48.0"
+    "@shopify/cli-kit" "3.48.1"
 
 "@sigstore/bundle@^1.0.0":
   version "1.0.0"
@@ -1753,6 +1754,11 @@ bl@^4.0.3, bl@^4.1.0:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
+
+bottleneck@2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Update to 3.48.1 of Shopify CLI packages.