### PR TITLE
Restrict deployment strategies

### DIFF
--- a/bin/generate-readme.sh
+++ b/bin/generate-readme.sh
@@ -1,0 +1,2 @@
+cd docs/commands
+npx oclif readme

--- a/docs/commands/readme.md
+++ b/docs/commands/readme.md
@@ -17,6 +17,7 @@
 * [`shopkeeper plugins:uninstall PLUGIN...`](#shopkeeper-pluginsuninstall-plugin-2)
 * [`shopkeeper plugins update`](#shopkeeper-plugins-update)
 * [`shopkeeper theme deploy`](#shopkeeper-theme-deploy)
+* [`shopkeeper theme get`](#shopkeeper-theme-get)
 * [`shopkeeper theme settings download`](#shopkeeper-theme-settings-download)
 
 ## `shopkeeper bucket create`
@@ -35,7 +36,7 @@ DESCRIPTION
   Create a bucket in .shopkeeper
 ```
 
-_See code: [dist/commands/bucket/create.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/bucket/create.ts)_
+_See code: [dist/commands/bucket/create.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/bucket/create.ts)_
 
 ## `shopkeeper bucket current`
 
@@ -53,7 +54,7 @@ DESCRIPTION
   Output the current bucket
 ```
 
-_See code: [dist/commands/bucket/current.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/bucket/current.ts)_
+_See code: [dist/commands/bucket/current.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/bucket/current.ts)_
 
 ## `shopkeeper bucket init`
 
@@ -71,7 +72,7 @@ DESCRIPTION
   Initialize .shopkeeper directory in the current directory
 ```
 
-_See code: [dist/commands/bucket/init.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/bucket/init.ts)_
+_See code: [dist/commands/bucket/init.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/bucket/init.ts)_
 
 ## `shopkeeper bucket restore [BUCKET]`
 
@@ -88,14 +89,14 @@ FLAGS
   -e, --environment=<value>  The environment to apply to the current command.
   -n, --nodelete             Runs the restore command without removing the theme's JSON settings.
   --no-color                 Disable color output.
-  --path=<value>             [default: .] The path to your theme directory.
+  --path=<value>             [default: /Users/jeff/Beyond/shopkeeper] The path to your theme directory.
   --verbose                  Increase the verbosity of the logs.
 
 DESCRIPTION
   Restores the theme settings from the specified bucket
 ```
 
-_See code: [dist/commands/bucket/restore.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/bucket/restore.ts)_
+_See code: [dist/commands/bucket/restore.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/bucket/restore.ts)_
 
 ## `shopkeeper bucket save [BUCKET]`
 
@@ -112,14 +113,14 @@ FLAGS
   -e, --environment=<value>  The environment to apply to the current command.
   -n, --nodelete             Runs the save command without deleting the bucket's contents.
   --no-color                 Disable color output.
-  --path=<value>             [default: .] The path to your theme directory.
+  --path=<value>             [default: /Users/jeff/Beyond/shopkeeper] The path to your theme directory.
   --verbose                  Increase the verbosity of the logs.
 
 DESCRIPTION
   Saves the current theme settings to the specified bucket
 ```
 
-_See code: [dist/commands/bucket/save.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/bucket/save.ts)_
+_See code: [dist/commands/bucket/save.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/bucket/save.ts)_
 
 ## `shopkeeper bucket switch [BUCKET]`
 
@@ -136,14 +137,14 @@ FLAGS
   -e, --environment=<value>  The environment to apply to the current command.
   -n, --nodelete             Runs the restore command without removing the theme's JSON settings.
   --no-color                 Disable color output.
-  --path=<value>             [default: .] The path to your theme directory.
+  --path=<value>             [default: /Users/jeff/Beyond/shopkeeper] The path to your theme directory.
   --verbose                  Increase the verbosity of the logs.
 
 DESCRIPTION
   Switches the current bucket by copying settings and .env
 ```
 
-_See code: [dist/commands/bucket/switch.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/bucket/switch.ts)_
+_See code: [dist/commands/bucket/switch.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/bucket/switch.ts)_
 
 ## `shopkeeper help [COMMANDS]`
 
@@ -415,7 +416,7 @@ Deploy theme source to store
 ```
 USAGE
   $ shopkeeper theme deploy [--no-color] [--verbose] [--path <value>] [--password <value>] [-s <value>] [-e
-    <value>] [-n] [--green <value>] [--blue <value>]
+    <value>] [-n] [--green <value>] [--blue <value>] [--strategy blue-green|basic]
 
 FLAGS
   -e, --environment=<value>  The environment to apply to the current command.
@@ -426,14 +427,39 @@ FLAGS
   --green=<value>            Green theme ID
   --no-color                 Disable color output.
   --password=<value>         Password generated from the Theme Access app.
-  --path=<value>             [default: .] The path to your theme directory.
+  --path=<value>             [default: /Users/jeff/Beyond/shopkeeper] The path to your theme directory.
+  --strategy=<option>        [default: blue-green] Strategy to use for deployment
+                             <options: blue-green|basic>
   --verbose                  Increase the verbosity of the logs.
 
 DESCRIPTION
   Deploy theme source to store
 ```
 
-_See code: [dist/commands/theme/deploy.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/theme/deploy.ts)_
+_See code: [dist/commands/theme/deploy.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/theme/deploy.ts)_
+
+## `shopkeeper theme get`
+
+Get details of theme
+
+```
+USAGE
+  $ shopkeeper theme get -t <value> [--no-color] [--verbose] [-s <value>] [--password <value>] [-j]
+
+FLAGS
+  -j, --json           Output JSON instead of a UI.
+  -s, --store=<value>  Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL
+                       (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).
+  -t, --theme=<value>  (required) Theme ID or name of the remote theme.
+  --no-color           Disable color output.
+  --password=<value>   Password generated from the Theme Access app.
+  --verbose            Increase the verbosity of the logs.
+
+DESCRIPTION
+  Get details of theme
+```
+
+_See code: [dist/commands/theme/get.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/theme/get.ts)_
 
 ## `shopkeeper theme settings download`
 
@@ -452,12 +478,12 @@ FLAGS
   -t, --theme=<value>        Theme ID or name of the remote theme.
   --no-color                 Disable color output.
   --password=<value>         Password generated from the Theme Access app.
-  --path=<value>             [default: .] The path to your theme directory.
+  --path=<value>             [default: /Users/jeff/Beyond/shopkeeper] The path to your theme directory.
   --verbose                  Increase the verbosity of the logs.
 
 DESCRIPTION
   Download settings from live theme.
 ```
 
-_See code: [dist/commands/theme/settings/download.ts](https://github.com/TheBeyondGroup/shopkeeper/blob/v1.0.0/dist/commands/theme/settings/download.ts)_
+_See code: [dist/commands/theme/settings/download.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/theme/settings/download.ts)_
 <!-- commandsstop -->

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.0",
   "commands": {
     "bucket:create": {
       "id": "bucket:create",
@@ -308,8 +308,11 @@
           "name": "strategy",
           "type": "option",
           "description": "Strategy to use for deployment",
-          "hidden": true,
           "multiple": false,
+          "options": [
+            "blue-green",
+            "basic"
+          ],
           "relationships": [
             {
               "type": "all",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
       "@oclif/plugin-help",
       "@oclif/plugin-plugins"
     ],
+    "repositoryPrefix": "<%- repo %>/tree/main/src/<%- commandPath %>",
     "topicSeparator": " "
   },
   "scripts": {
@@ -60,7 +61,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "postpublish": "npm publish --ignore-scripts --@thebeyondgroup:registry='https://registry.npmjs.org'",
-    "prepack": "yarn build && oclif manifest",
+    "prepack": "yarn build && oclif manifest && ./bin/generate-readme.sh",
     "test": "mocha --forbid-only \"test/**/*.test.ts\""
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@oclif/core": "2.8.11",
     "@oclif/plugin-commands": "2.2.17",
     "@oclif/plugin-help": "5.2.1",
-    "@shopify/cli": "3.48.3",
-    "@shopify/cli-kit": "3.48.3",
-    "@shopify/theme": "3.48.3",
+    "@shopify/cli": "3.48.4",
+    "@shopify/cli-kit": "3.48.4",
+    "@shopify/theme": "3.48.4",
     "fs-extra": "^11.1.0"
   },
   "devDependencies": {

--- a/src/commands/theme/deploy.ts
+++ b/src/commands/theme/deploy.ts
@@ -5,7 +5,7 @@ import { themeFlags } from '@shopify/theme/dist/cli/flags.js';
 import { ensureThemeStore } from '@shopify/theme/dist/cli/utilities/theme-store.js';
 import ThemeCommand from '@shopify/theme/dist/cli/utilities/theme-command.js';
 import { deploy } from '../../services/theme/deploy.js';
-import { BLUE_GREEN_STRATEGY } from '../../utilities/constants.js';
+import { BLUE_GREEN_STRATEGY, DEPLOYMENT_STRATEGIES } from '../../utilities/constants.js';
 
 export default class Deploy extends ThemeCommand {
   static description = "Deploy theme source to store";
@@ -28,8 +28,8 @@ export default class Deploy extends ThemeCommand {
     }),
     strategy: Flags.string({
       description: 'Strategy to use for deployment',
-      hidden: true,
       default: BLUE_GREEN_STRATEGY,
+      options: DEPLOYMENT_STRATEGIES,
       env: 'SKR_FLAG_STRATEGY',
       relationships: [
         {

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -3,3 +3,4 @@ export const LEGACY_CURRENT_BUCKET_FILE = ".current-store";
 export const CURRENT_BUCKET_FILE = ".current-bucket";
 export const BLUE_GREEN_STRATEGY = "blue-green"
 export const BASIC_STRATEGY = "basic"
+export const DEPLOYMENT_STRATEGIES = [BLUE_GREEN_STRATEGY, BASIC_STRATEGY]

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,7 +672,43 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^2.0.3", "@oclif/core@^2.11.4", "@oclif/core@^2.11.7", "@oclif/core@^2.11.8", "@oclif/core@^2.8.10", "@oclif/core@^2.8.11", "@oclif/core@^2.8.2":
+"@oclif/core@^2.0.3", "@oclif/core@^2.11.10", "@oclif/core@^2.11.4":
+  version "2.11.10"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.11.10.tgz#638128034b8b4bdf4b23480a7278426f85130170"
+  integrity sha512-/7Umij3OU++6o+z4U+waJ5nP6IvK9KKEVzz+xsla68YoECLQwz43boUKqYizlNMtTfiwNkiYb5QE+OU/q5qEtA==
+  dependencies:
+    "@types/cli-progress" "^3.11.0"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.12.0"
+    debug "^4.3.4"
+    ejs "^3.1.8"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    semver "^7.5.3"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    ts-node "^10.9.1"
+    tslib "^2.5.0"
+    widest-line "^3.1.0"
+    wordwrap "^1.0.0"
+    wrap-ansi "^7.0.0"
+
+"@oclif/core@^2.11.7", "@oclif/core@^2.11.8", "@oclif/core@^2.8.10", "@oclif/core@^2.8.11", "@oclif/core@^2.8.2":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.11.8.tgz#780c4fdf53e8569cf754c2a8fefcc7ddeacf1747"
   integrity sha512-GILmztcHBzze45GvxRpUvqQI5nM26kSE/Q21Y+6DtMR+C8etM/hFW26D3uqIAbGlGtg5QEZZ6pjA/Fqgz+gl3A==
@@ -777,11 +813,11 @@
     semver "^7.5.4"
 
 "@oclif/test@^2.3.3":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@oclif/test/-/test-2.4.6.tgz#4f6a9d7a5a79e9188aaa5c120477fb57592a0ee3"
-  integrity sha512-lI3I+gqCzkY0yXWCyaIPhVoYJXyBhH7dHq9BkLeBtiaMTMlUsjOIYrO8azfUmFI58Qa1sgsrpbuuo5PBO2RFew==
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@oclif/test/-/test-2.4.7.tgz#4372270157aa6598c0d1b61349b2eff4e2003193"
+  integrity sha512-r18sKGNUm/VGQ8BkSF9Kn7QeMGjGMDUrLxTDPzL5ERaBF5YSi+O9CT3mKhcFdrMwGnCqPVvlAdX4U/6gtYPy1A==
   dependencies:
-    "@oclif/core" "^2.11.8"
+    "@oclif/core" "^2.11.10"
     fancy-test "^2.0.34"
 
 "@octokit/auth-token@^2.4.4":
@@ -911,10 +947,10 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@shopify/cli-kit@3.48.3":
-  version "3.48.3"
-  resolved "https://registry.yarnpkg.com/@shopify/cli-kit/-/cli-kit-3.48.3.tgz#cbe8159b69b6757633caa41d09affc15d837a441"
-  integrity sha512-LayflHepneaglYslaPCTo/XrOFsSw/rBPQyKWETgQWK8coqmfxmii/Pn6zG31M3TkYlD9VxrCR9sLIsuxsEk7Q==
+"@shopify/cli-kit@3.48.4":
+  version "3.48.4"
+  resolved "https://registry.yarnpkg.com/@shopify/cli-kit/-/cli-kit-3.48.4.tgz#34f701294ea591f577209c8aea730a334694902c"
+  integrity sha512-u/RkyjuU+/lH7EXJEsKxeRx4zbJy8KYF63NdgJp+ukD+BX3tJ1UMcFPEagS7hQA1f3EBqkVBg0bV4qznAWnQDQ==
   dependencies:
     "@bugsnag/js" "7.20.2"
     "@iarna/toml" "2.2.5"
@@ -976,35 +1012,35 @@
     unique-string "3.0.0"
     zod "3.21.4"
 
-"@shopify/cli@3.48.3":
-  version "3.48.3"
-  resolved "https://registry.yarnpkg.com/@shopify/cli/-/cli-3.48.3.tgz#ff62a5eb328e01667971580e5170f7bad7e87fe0"
-  integrity sha512-gxetT+2HyklyLUnZxZBYyhYFhLENtHM9jSnDCBCRVG0Dgcl4E0ZxF32xqlULhl0F0H/DIrjyjjD9YF/7q5PMOg==
+"@shopify/cli@3.48.4":
+  version "3.48.4"
+  resolved "https://registry.yarnpkg.com/@shopify/cli/-/cli-3.48.4.tgz#9f276840bb8cb6db6a45d321dc03ba0c6f46dbbd"
+  integrity sha512-MT2fYZusPpFcJls6XMnQw07+nQsOVj0+UcWDVU4uyib9Y1AbQ3DstBQgyLOSSn5bd1vnVBk3LhzD4FLBbA2P/A==
   dependencies:
     "@oclif/core" "2.8.11"
     "@oclif/plugin-commands" "2.2.17"
     "@oclif/plugin-help" "5.2.11"
     "@oclif/plugin-plugins" "2.4.7"
-    "@shopify/cli-kit" "3.48.3"
-    "@shopify/plugin-did-you-mean" "3.48.3"
+    "@shopify/cli-kit" "3.48.4"
+    "@shopify/plugin-did-you-mean" "3.48.4"
     zod-to-json-schema "3.21.3"
 
-"@shopify/plugin-did-you-mean@3.48.3":
-  version "3.48.3"
-  resolved "https://registry.yarnpkg.com/@shopify/plugin-did-you-mean/-/plugin-did-you-mean-3.48.3.tgz#05fab9f05f18cdbf90f9189a262ecc6dc4e7c91b"
-  integrity sha512-f/PfVuH6HVC09v2VQlDuuHs0G3cU/DZzewhPvzI+0FGwiCcRUbMqSaLd5OC4Mre6AI/4T955jFulVVT72Gr4Ug==
+"@shopify/plugin-did-you-mean@3.48.4":
+  version "3.48.4"
+  resolved "https://registry.yarnpkg.com/@shopify/plugin-did-you-mean/-/plugin-did-you-mean-3.48.4.tgz#0a56f184a6b80aec1545c3f9c7073c6b0ae1ee3f"
+  integrity sha512-Wu6sDEbRs+gTIVaGVPB1N1ewlaqOoBX2MdiOG1jC8tkaYklyrVY5mGX3gFo7PCrX0JYOgxtAHZD0woR860VFEQ==
   dependencies:
     "@oclif/core" "2.8.11"
-    "@shopify/cli-kit" "3.48.3"
+    "@shopify/cli-kit" "3.48.4"
     n-gram "2.0.2"
 
-"@shopify/theme@3.48.3":
-  version "3.48.3"
-  resolved "https://registry.yarnpkg.com/@shopify/theme/-/theme-3.48.3.tgz#b79ee9ae7929f01dc7ab070ca2d23ad8f6091224"
-  integrity sha512-936blvsNyqnzfEXBOdtZQSFtsCF6kAMPGUrL8Fo0IO+jqfkYS0sAtlPNV9MPr/6ofSKNdBziX7TPT7h60UV11g==
+"@shopify/theme@3.48.4":
+  version "3.48.4"
+  resolved "https://registry.yarnpkg.com/@shopify/theme/-/theme-3.48.4.tgz#f60ab56c695eac588720792ea00394039e11844d"
+  integrity sha512-cKwiCbAMeVPiLvBqH2mEAqfnzF7Cb1g0mnwkyWqiNSj2gP/zFBy3T3OlpYVT1OKVi5fML1rk+BIdwUpIILhoow==
   dependencies:
     "@oclif/core" "2.8.11"
-    "@shopify/cli-kit" "3.48.3"
+    "@shopify/cli-kit" "3.48.4"
 
 "@sigstore/bundle@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
We want to provide better error messages when an unsupported strategy is passed. By putting this restriction at the flag parser level, we don't need to add a guard to ensure the strategy is one of the expected ones. Also, this prevents people from getting an unexpected result because our switch statement in the implementation that defaults to the basic strategy. This could have an unexpected result.