### PR TITLE
Add success message to `bucket init`

### DIFF
--- a/src/services/bucket/init.ts
+++ b/src/services/bucket/init.ts
@@ -1,6 +1,9 @@
 import { mkdir } from "@shopify/cli-kit/node/fs"
+import { renderSuccess } from "@shopify/cli-kit/node/ui"
 import { SHOPKEEPER_DIRECTORY } from "../../utilities/constants.js"
 
 export async function init() {
-  mkdir(`./${SHOPKEEPER_DIRECTORY}`)
+  await mkdir(`./${SHOPKEEPER_DIRECTORY}`)
+
+  renderSuccess({ body: `${SHOPKEEPER_DIRECTORY} directory created.` })
 }


### PR DESCRIPTION
Let's make it clear we succeeded.