### PR TITLE
Implement `theme create`

### DIFF
--- a/docs/commands/readme.md
+++ b/docs/commands/readme.md
@@ -16,6 +16,7 @@
 * [`shopkeeper plugins:uninstall PLUGIN...`](#shopkeeper-pluginsuninstall-plugin-1)
 * [`shopkeeper plugins:uninstall PLUGIN...`](#shopkeeper-pluginsuninstall-plugin-2)
 * [`shopkeeper plugins update`](#shopkeeper-plugins-update)
+* [`shopkeeper theme create`](#shopkeeper-theme-create)
 * [`shopkeeper theme deploy`](#shopkeeper-theme-deploy)
 * [`shopkeeper theme get`](#shopkeeper-theme-get)
 * [`shopkeeper theme settings download`](#shopkeeper-theme-settings-download)
@@ -408,6 +409,44 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.7/src/commands/plugins/update.ts)_
+
+## `shopkeeper theme create`
+
+Create a theme with theme name or ID.
+
+```
+USAGE
+  $ shopkeeper theme create -t <value> [--no-color] [--verbose] [--path <value>] [--password <value>] [-s <value>]
+    [-e <value>] [-n] [-j]
+
+FLAGS
+  -e, --environment=<value>  The environment to apply to the current command.
+  -j, --json                 Output JSON instead of a UI.
+  -n, --nodelete             Runs the push command without deleting local files.
+  -s, --store=<value>        Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL
+                             (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).
+  -t, --theme=<value>        (required) Theme ID or name of the remote theme.
+  --no-color                 Disable color output.
+  --password=<value>         Password generated from the Theme Access app.
+  --path=<value>             [default: /Users/jeff/Beyond/shopkeeper] The path to your theme directory.
+  --verbose                  Increase the verbosity of the logs.
+
+DESCRIPTION
+
+  Create a theme with theme name or ID.
+  In most cases, you should use theme push.
+
+  This command exists for the case when you want create a theme by name that may
+  or may not exist. It will ensure that if one with the same name already exists,
+  it is updated.
+
+  theme push --unpublished --theme yellow will create a new theme named yellow each
+  time the command is run.
+
+  As a result this command exists.
+```
+
+_See code: [dist/commands/theme/create.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/dist/commands/theme/create.ts)_
 
 ## `shopkeeper theme deploy`
 

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -235,6 +235,87 @@
         }
       }
     },
+    "theme:create": {
+      "id": "theme:create",
+      "description": "\nCreate a theme with theme name or ID.\nIn most cases, you should use theme push.\n\nThis command exists for the case when you want create a theme by name that may\nor may not exist. It will ensure that if one with the same name already exists,\nit is updated.\n\ntheme push --unpublished --theme yellow will create a new theme named yellow each\ntime the command is run.\n\nAs a result this command exists.\n",
+      "strict": true,
+      "pluginName": "@thebeyondgroup/shopkeeper",
+      "pluginAlias": "@thebeyondgroup/shopkeeper",
+      "pluginType": "core",
+      "aliases": [],
+      "flags": {
+        "no-color": {
+          "name": "no-color",
+          "type": "boolean",
+          "description": "Disable color output.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "Increase the verbosity of the logs.",
+          "hidden": false,
+          "allowNo": false
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "description": "The path to your theme directory.",
+          "multiple": false,
+          "default": "/Users/jeff/Beyond/shopkeeper"
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "description": "Password generated from the Theme Access app.",
+          "multiple": false
+        },
+        "store": {
+          "name": "store",
+          "type": "option",
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (johns-apparel) or the full myshopify.com URL (johns-apparel.myshopify.com, https://johns-apparel.myshopify.com).",
+          "multiple": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "multiple": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "option",
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "required": true,
+          "multiple": false
+        },
+        "nodelete": {
+          "name": "nodelete",
+          "type": "boolean",
+          "char": "n",
+          "description": "Runs the push command without deleting local files.",
+          "allowNo": false
+        },
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "char": "j",
+          "description": "Output JSON instead of a UI.",
+          "allowNo": false
+        }
+      },
+      "args": {},
+      "cli2Flags": [
+        "theme",
+        "nodelete",
+        "json",
+        "unpublished"
+      ]
+    },
     "theme:deploy": {
       "id": "theme:deploy",
       "description": "Deploy theme source to store",

--- a/src/commands/theme/create.ts
+++ b/src/commands/theme/create.ts
@@ -1,0 +1,69 @@
+import { Flags } from '@oclif/core';
+import { globalFlags } from "@shopify/cli-kit/node/cli";
+import { ensureAuthenticatedThemes } from "@shopify/cli-kit/node/session";
+import { themeFlags } from "@shopify/theme/dist/cli/flags.js";
+import { ensureThemeStore } from "@shopify/theme/dist/cli/utilities/theme-store.js";
+import ThemeCommand from '@shopify/theme/dist/cli/utilities/theme-command.js';
+import { execCLI2 } from '@shopify/cli-kit/node/ruby';
+import { getThemesByIdentifier } from '../../utilities/theme.js';
+import { AbortError } from '@shopify/cli-kit/node/error';
+
+export default class Create extends ThemeCommand {
+  static description = `
+Create a theme with theme name or ID.
+In most cases, you should use theme push.
+
+This command exists for the case when you want create a theme by name that may
+or may not exist. It will ensure that if one with the same name already exists,
+it is updated.
+
+theme push --unpublished --theme yellow will create a new theme named yellow each
+time the command is run.
+
+As a result this command exists.
+`;
+
+  static flags = {
+    ...globalFlags,
+    ...themeFlags,
+    theme: Flags.string({
+      char: 't',
+      required: true,
+      description: 'Theme ID or name of the remote theme.',
+      env: 'SHOPIFY_FLAG_THEME_ID',
+    }),
+    nodelete: Flags.boolean({
+      char: 'n',
+      description: 'Runs the push command without deleting local files.',
+      env: 'SHOPIFY_FLAG_NODELETE',
+    }),
+    json: Flags.boolean({
+      char: 'j',
+      description: 'Output JSON instead of a UI.',
+      env: 'SHOPIFY_FLAG_JSON',
+    }),
+  };
+
+  static cli2Flags = [
+    'theme',
+    'nodelete',
+    'json',
+    'unpublished'
+  ]
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Create)
+    const store = ensureThemeStore(flags)
+    const adminSession = await ensureAuthenticatedThemes(store, flags.password)
+
+    const matchingThemes = await getThemesByIdentifier(adminSession, flags.theme!)
+    if (!matchingThemes.length) {
+      flags["unpublished"] = true
+    }
+
+    const flagsToPass = this.passThroughFlags(flags, { allowedFlags: Create.cli2Flags })
+    const command = ['theme', 'push', flags.path, ...flagsToPass]
+
+    await execCLI2(command, { store, adminToken: adminSession.token })
+  }
+}

--- a/src/utilities/theme.ts
+++ b/src/utilities/theme.ts
@@ -1,5 +1,8 @@
 import { execCLI2 } from "@shopify/cli-kit/node/ruby"
 import { AdminSession } from "@shopify/cli-kit/node/session"
+import { Theme } from "@shopify/cli-kit/node/themes/models/theme.js"
+import { fetchStoreThemes } from "@shopify/theme/dist/cli/utilities/theme-selector/fetch.js"
+import { Filter } from "@shopify/theme/dist/cli/utilities/theme-selector/filter.js"
 import { cli2settingFlags } from "./bucket.js"
 
 export async function pullLiveThemeSettings(adminSession: AdminSession, path: string, themeFlags: string[]): Promise<void> {
@@ -19,3 +22,31 @@ export async function pushLive(adminSession: AdminSession, path: string, themeFl
   const command = ['theme', 'push', path, ...themeFlags, ...themeFlag]
   await execCLI2(command, { store: adminSession.storeFqdn, adminToken: adminSession.token })
 }
+
+export async function getThemesByIdentifier(adminSession: AdminSession, theme: string): Promise<Theme[]> {
+  let storeThemes = await fetchStoreThemes(adminSession)
+  const filter = new Filter({ theme: theme })
+
+  if (filter.any()) {
+    storeThemes = filterByTheme(storeThemes, filter)
+  }
+
+  return storeThemes
+}
+
+// These functions are near direct copies of the ones in the Shopify CLI codebase.
+// They have been modified to not throw errors
+export function filterByTheme(themes: Theme[], filter: Filter): Theme[] {
+  const identifiers = filter.themeIdentifiers
+  return identifiers.flatMap((identifier) => {
+    return filterArray(themes, (theme) => {
+      return `${theme.id}` === identifier || theme.name.toLowerCase().includes(identifier.toLowerCase())
+    })
+  })
+}
+
+
+export function filterArray(themes: Theme[], predicate: (theme: Theme) => boolean): Theme[] {
+  return themes.filter(predicate)
+}
+


### PR DESCRIPTION
This is a piece of code I wish didn't need to exist. However, it is the easiest way to solve a problem we experience in CI. We need the ability to create themes of a particular name in an idempotent way.

`theme push --unpublished --theme yellow` will create a new theme named yellow each
time the command is run.

`theme push --theme yellow` will fail unless yellow already exists.

Therefore, logic is needed to determine which command to run.

To make preview themes, we need an idempotent way to create themes of a given name.