### PR TITLE
Update theme init to affect .gitignore

### DIFF
--- a/src/services/bucket/init.ts
+++ b/src/services/bucket/init.ts
@@ -1,9 +1,41 @@
-import { mkdir } from "@shopify/cli-kit/node/fs"
+import { appendFile, fileExists, mkdir, writeFile } from "@shopify/cli-kit/node/fs"
 import { renderSuccess } from "@shopify/cli-kit/node/ui"
 import { SHOPKEEPER_DIRECTORY } from "../../utilities/constants.js"
 
 export async function init() {
   await mkdir(`./${SHOPKEEPER_DIRECTORY}`)
 
-  renderSuccess({ body: `${SHOPKEEPER_DIRECTORY} directory created.` })
+  let action = ""
+  if (await fileExists('./.gitignore')) {
+    await appendFile('./.gitignore', gitIgnoreContent)
+    action = "updated"
+  } else {
+    await writeFile('./.gitignore', gitIgnoreContent)
+    action = "created"
+  }
+  renderSuccess({
+    body: {
+      list:
+      {
+        items: [
+          `${SHOPKEEPER_DIRECTORY} directory created`,
+          `.gitignore ${action}`
+        ]
+      }
+    }
+  })
 }
+
+const gitIgnoreContent = `# Shopkeeper #
+##########
+.shopkeeper/**/**/.env
+.shopkeeper/.current-bucket
+.env
+
+# Theme #
+##########
+theme/assets
+theme/config/settings_data.json
+theme/templates/**/*.json
+theme/sections/*.json
+`


### PR DESCRIPTION
When we install Shopkeeper, we want our .gitignore to match the convention of storing settings in .shopkeeper.

This is a first pass of this feature. Writing code on behalf of a user is always a little tricky. At this point, we're doing a naive append or create. I'm open to more sophistication in the future, but for a command that's run infrequently a project, it's not worth the effort right now.