### PR TITLE
Fix command link

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Shopkeeper supports multiple deployment strategies:
 * Blue/Green
 
 Shopkeeper extends the Shopify CLI `theme` topic with a 
-[`deploy`](docs/commands/readme#shopkeeper-theme-deploy) command.
+[`deploy`](docs/commands/readme.md#shopkeeper-theme-deploy) command.
 
 ### Basic Deployment
 


### PR DESCRIPTION
In this PR, I fix a link in the readme to the `theme deploy` command.