### PR TITLE
Use explicit pattern for customers the subdirectory for CLI glob

### DIFF
--- a/src/utilities/bucket.ts
+++ b/src/utilities/bucket.ts
@@ -85,7 +85,7 @@ export async function setCurrentBucket(bucket: string) {
   await writeFile(`${shopkeeperRoot}/${CURRENT_BUCKET_FILE}`, contents)
 }
 
-export function getSettingsPatterns() {
+export function getSettingsPatterns(): string[] {
   return [
     'config/settings_data.json',
     'templates/**/*.json',
@@ -93,8 +93,22 @@ export function getSettingsPatterns() {
   ]
 }
 
+export function getCLISettingsPatterns(): string[] {
+  return [
+    'config/settings_data.json',
+    'sections/*.json',
+    'templates/*.json',
+    'templates/customers/*.json'
+  ]
+}
+
 export function cli2settingFlags() {
-  const patternFlags = getSettingsPatterns().flatMap(pattern => {
+  const patternFlags = [
+    'config/settings_data.json',
+    'sections/*.json',
+    'templates/*.json',
+    'templates/customers/*.json'
+  ].flatMap(pattern => {
     return ["--only", `${pattern}`]
   })
 


### PR DESCRIPTION
Somehow I missed it in my testing that the CLI flag --only does not take true directory globs. I think I knew this from the previous version, but forgot.

`templates/customers/*.json` must be used instead of `templates/**/*.json`