### PR TITLE
Set Shopkeeper to depend on the latest Shopify 3.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@oclif/core": "2.8.11",
     "@oclif/plugin-commands": "2.2.17",
     "@oclif/plugin-help": "5.2.1",
-    "@shopify/cli": "~3.48.4",
-    "@shopify/cli-kit": "~3.48.4",
-    "@shopify/theme": "~3.48.4",
+    "@shopify/cli": "3.x",
+    "@shopify/cli-kit": "3.x",
+    "@shopify/theme": "3.x",
     "fs-extra": "^11.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Previously, we limited the versions to patch updates of 3.48. The reality is Shopify continues to interate at a quick pace and I'm not sure we want to constrain ourselves to the minor version. This would require a fresh Shopkeeper release each time Shopify increments the minor version. This would add extra maintenance overhead. If Shopify becomes careless with its releases, we'll lock things down. However, being the pros they are, I think it's safe to constrain ourselves to 3.x.