### PR TITLE
feat: add support for metaobject templates

### DIFF
--- a/src/utilities/bucket.ts
+++ b/src/utilities/bucket.ts
@@ -118,7 +118,8 @@ export const CLI_SETTINGS_FLAGS = [
   'config/settings_data.json',
   'sections/*.json',
   'templates/*.json',
-  'templates/customers/*.json'
+  'templates/customers/*.json',
+  'templates/metaobject/*.json'
 ]
 
 export function cli2settingFlags() {


### PR DESCRIPTION
A short while ago, Shopify added support for metaobject type pages. For example, if you have a metaobject `Author`, you can define a template that will render that author at `/pages/authors/<slug>`.

We need to make Shopkeeper aware of these templates.