### PR TITLE
chore: suggest mise instead of direnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,13 @@ this pattern:
 | `SKR_FLAG_BLUE_THEME_ID`| blue theme ID, cannot be name as name will be update   |
 | `SKR_FLAG_GREEN_THEME_ID`| green theme ID, cannot be name as name will be update   |
 
-Using a tool like [direnv](https://direnv.net), you can have your environment variables automatically
+Using a tool like [mise](https://mise.jdx.dev/environments/), you can have your environment variables automatically
 updated when you switch buckets.
+
+Setting the following in your shell is a great way to reduce the config needed in your repo.
+```
+MISE_ENV_FILE=.env 
+ ```
 
 ## Contribute
 If you'd like to contribute to the project, check out the [contributors docs](docs/contribute.md) to get started.


### PR DESCRIPTION
direnv requires a little more setup that we think is good. mise, on the other hand, is an excellent runtime version manager and we STRONGLY recommend it to manage node versions and other runtimes.

Closes #160 