### PR TITLE
fix: refactor theme settings download command

### DIFF
--- a/src/commands/theme/settings/download.ts
+++ b/src/commands/theme/settings/download.ts
@@ -1,8 +1,8 @@
-import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import { Flags } from '@oclif/core'
+import { globalFlags } from '@shopify/cli-kit/node/cli'
 import BaseCommand from '@shopify/cli-kit/node/base-command'
-import {themeFlags} from '../../../utilities/shopify/flags.js'
-import {pullThemeSettings} from '../../../utilities/theme.js'
+import { themeFlags } from '../../../utilities/shopify/flags.js'
+import { downloadThemeSettings, DownloadFlags } from '../../../utilities/theme.js'
 
 export default class Download extends BaseCommand {
   static description = 'Download settings from live theme.'
@@ -33,20 +33,7 @@ export default class Download extends BaseCommand {
   }
 
   async run(): Promise<void> {
-    const {flags} = await this.parse(Download)
-
-    const pullflags = {
-      verbose: flags.verbose,
-      noColor: flags['no-color'],
-      path: flags.path,
-      password: flags.password,
-      store: flags.store,
-      theme: flags.theme,
-      development: flags.development,
-      live: flags.live ?? true,
-      nodelete: flags.nodelete,
-    }
-
-    await pullThemeSettings(pullflags)
+    const { flags } = await this.parse(Download)
+    await downloadThemeSettings(flags as DownloadFlags)
   }
 }

--- a/src/utilities/theme.test.ts
+++ b/src/utilities/theme.test.ts
@@ -1,15 +1,18 @@
-import {describe, expect, test, vi} from 'vitest'
-import {deployTheme, deployToLive, getThemesByIdentifier, pullLiveThemeSettings, pullThemeSettings} from './theme.js'
-import {fetchStoreThemes, pull, push} from '@shopify/cli'
-import {Theme} from '@shopify/cli-kit/node/themes/types'
-import {PullFlags} from './shopify/services/pull.js'
-import {PushFlags} from './shopify/services/push.js'
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { deployTheme, deployToLive, DownloadFlags, downloadThemeSettings, getThemesByIdentifier, pullLiveThemeSettings, pullThemeSettings } from './theme.js'
+import { fetchStoreThemes, pull, push } from '@shopify/cli'
+import { Theme } from '@shopify/cli-kit/node/themes/types'
+import { PullFlags } from './shopify/services/pull.js'
+import { PushFlags } from './shopify/services/push.js'
 
 vi.mock('@shopify/cli')
 
 describe('theme utilities', () => {
-  const adminSession = {token: 'ABC', storeFqdn: 'example.myshopify.com'}
-  const path = '/my-theme'
+  const adminSession = { token: 'ABC', storeFqdn: 'example.myshopify.com' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
   describe('pullThemeSettings', () => {
     test('pulls settings from theme', async () => {
@@ -66,6 +69,394 @@ describe('theme utilities', () => {
     })
   })
 
+  describe('downloadThemeSettings', () => {
+    describe('flag transformation and pass-through', () => {
+      test('passes all flags correctly when live flag is explicitly set', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          live: true,
+          nodelete: true,
+          verbose: true,
+          'no-color': false,
+          path: '/my-theme',
+          password: 'test-token',
+          store: 'test.myshopify.com',
+          theme: undefined,
+          development: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: true,
+          noColor: false,
+          path: '/my-theme',
+          password: 'test-token',
+          store: 'test.myshopify.com',
+          theme: undefined,
+          development: undefined,
+          live: true,
+          nodelete: true,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+
+      test('passes all flags correctly when development flag is set', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          development: true,
+          nodelete: false,
+          verbose: false,
+          'no-color': true,
+          path: '/dev-theme',
+          password: 'dev-token',
+          store: 'dev.myshopify.com',
+          theme: undefined,
+          live: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: false,
+          noColor: true,
+          path: '/dev-theme',
+          password: 'dev-token',
+          store: 'dev.myshopify.com',
+          theme: undefined,
+          development: true,
+          live: false,
+          nodelete: false,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+
+      test('passes all flags correctly when specific theme is set', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          theme: '123456',
+          nodelete: true,
+          verbose: false,
+          'no-color': false,
+          path: '/specific-theme',
+          password: 'theme-token',
+          store: 'store.myshopify.com',
+          development: undefined,
+          live: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: false,
+          noColor: false,
+          path: '/specific-theme',
+          password: 'theme-token',
+          store: 'store.myshopify.com',
+          theme: '123456',
+          development: undefined,
+          live: false,
+          nodelete: true,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+
+      test('defaults to live theme when no theme, development, or live flags are set', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          nodelete: true,
+          verbose: true,
+          'no-color': true,
+          path: '/default-theme',
+          password: 'default-token',
+          store: 'default.myshopify.com',
+          theme: undefined,
+          development: undefined,
+          live: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: true,
+          noColor: true,
+          path: '/default-theme',
+          password: 'default-token',
+          store: 'default.myshopify.com',
+          theme: undefined,
+          development: undefined,
+          live: true,
+          nodelete: true,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+
+      test('correctly transforms no-color flag to noColor', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          'no-color': true,
+          verbose: false,
+          path: '/color-test',
+          password: 'color-token',
+          store: 'color.myshopify.com',
+          nodelete: false,
+          theme: undefined,
+          development: undefined,
+          live: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: false,
+          noColor: true,
+          path: '/color-test',
+          password: 'color-token',
+          store: 'color.myshopify.com',
+          theme: undefined,
+          development: undefined,
+          live: true,
+          nodelete: false,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+    })
+
+    describe('live flag default logic', () => {
+      test('live is true when neither theme nor development are set', async () => {
+        const flags: DownloadFlags = { theme: undefined, development: undefined, live: undefined }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: true,
+        }))
+      })
+
+      test('live is false when theme is set but live is not', async () => {
+        const flags: DownloadFlags = { theme: '123', development: undefined, live: undefined }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: false,
+        }))
+      })
+
+      test('live is false when development is set but live is not', async () => {
+        const flags: DownloadFlags = { theme: undefined, development: true, live: undefined }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: false,
+        }))
+      })
+
+      test('live is true when explicitly set to true', async () => {
+        const flags: DownloadFlags = { theme: '123', development: true, live: true }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: true,
+        }))
+      })
+
+      test('live is true when explicitly set to false but no theme or development', async () => {
+        const flags: DownloadFlags = { theme: undefined, development: undefined, live: false }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: true,
+        }))
+      })
+
+      test('live is false when explicitly set to false and theme is set', async () => {
+        const flags: DownloadFlags = { theme: '123', development: undefined, live: false }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: false,
+        }))
+      })
+
+      test('live is false when both theme and development are set but live is not', async () => {
+        const flags: DownloadFlags = { theme: '456', development: true, live: undefined }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          live: false,
+        }))
+      })
+    })
+
+    describe('edge cases', () => {
+      test('handles false values correctly for boolean flags', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          live: false,
+          development: false,
+          nodelete: false,
+          verbose: false,
+          'no-color': false,
+          path: '/false-flags',
+          password: 'false-token',
+          store: 'false.myshopify.com',
+          theme: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: false,
+          noColor: false,
+          path: '/false-flags',
+          password: 'false-token',
+          store: 'false.myshopify.com',
+          theme: undefined,
+          development: false,
+          live: true,
+          nodelete: false,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+
+      test('handles empty string values', async () => {
+        // Given
+        const flags: DownloadFlags = {
+          theme: '',
+          path: '',
+          password: '',
+          store: '',
+          verbose: false,
+          'no-color': false,
+          nodelete: false,
+          development: undefined,
+          live: undefined,
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: false,
+          noColor: false,
+          path: '',
+          password: '',
+          store: '',
+          theme: '',
+          development: undefined,
+          live: true,
+          nodelete: false,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+
+      test('handles all flags being undefined except required ones', async () => {
+        // Given
+        const flags = {
+          verbose: false,
+          'no-color': false,
+          path: '/minimal',
+          password: 'minimal-token',
+          store: 'minimal.myshopify.com',
+        }
+
+        // When
+        await downloadThemeSettings(flags)
+
+        // Then
+        expect(pull).toHaveBeenCalledWith({
+          verbose: false,
+          noColor: false,
+          path: '/minimal',
+          password: 'minimal-token',
+          store: 'minimal.myshopify.com',
+          theme: undefined,
+          development: undefined,
+          live: true,
+          nodelete: undefined,
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        })
+      })
+    })
+
+    describe('settings files filtering', () => {
+      test('always includes only settings files in pull request', async () => {
+        const flags = { live: true }
+        await downloadThemeSettings(flags)
+
+        expect(pull).toHaveBeenCalledWith(expect.objectContaining({
+          only: [
+            'config/settings_data.json',
+            'sections/*.json',
+            'templates/*.json',
+            'templates/customers/*.json',
+            'templates/metaobject/*.json',
+          ],
+        }))
+      })
+    })
+  })
+
   describe('deploy', () => {
     describe('when should publish automatically', () => {
       test('pushes theme files to theme', async () => {
@@ -109,6 +500,7 @@ describe('theme utilities', () => {
       })
     })
   })
+
   describe('deployToLive', () => {
     test('pushes theme files to live theme', async () => {
       // Given
@@ -128,7 +520,7 @@ describe('theme utilities', () => {
 
   describe('getThemesByIdentifier', () => {
     function theme(id: number, role: string) {
-      return {id, role, name: `theme (${id})`} as Theme
+      return { id, role, name: `theme (${id})` } as Theme
     }
 
     test('returns list of themes that match id or name', async () => {

--- a/src/utilities/theme.ts
+++ b/src/utilities/theme.ts
@@ -1,10 +1,21 @@
-import {AdminSession} from '@shopify/cli-kit/node/session'
-import {Theme} from '@shopify/cli-kit/node/themes/types.js'
-import {fetchStoreThemes, pull, push} from '@shopify/cli'
-import {PullFlags} from './shopify/services/pull.js'
-import {CLI_SETTINGS_FLAGS} from './bucket.js'
-import {Filter} from './shopify/theme-selector/filter.js'
-import {PushFlags} from './shopify/services/push.js'
+import { Theme } from '@shopify/cli-kit/node/themes/types.js'
+import { fetchStoreThemes, pull, push } from '@shopify/cli'
+import { PullFlags } from './shopify/services/pull.js'
+import { CLI_SETTINGS_FLAGS } from './bucket.js'
+import { Filter } from './shopify/theme-selector/filter.js'
+import { PushFlags } from './shopify/services/push.js'
+
+export interface DownloadFlags {
+  verbose?: boolean
+  'no-color'?: boolean
+  path?: string
+  password?: string
+  store?: string
+  theme?: string
+  development?: boolean
+  live?: boolean
+  nodelete?: boolean
+}
 
 export async function pullLiveThemeSettings(flags: PullFlags): Promise<void> {
   const pullFlags: PullFlags = {
@@ -21,6 +32,23 @@ export async function pullThemeSettings(flags: PullFlags): Promise<void> {
     ...flags,
     only: CLI_SETTINGS_FLAGS,
   }
+  await pull(pullFlags)
+}
+
+export async function downloadThemeSettings(flags: DownloadFlags): Promise<void> {
+  const pullFlags: PullFlags = {
+    verbose: flags.verbose,
+    noColor: flags['no-color'],
+    path: flags.path,
+    password: flags.password,
+    store: flags.store,
+    theme: flags.theme,
+    development: flags.development,
+    live: flags.live || !(flags.theme || flags.development),
+    nodelete: flags.nodelete,
+    only: CLI_SETTINGS_FLAGS,
+  }
+
   await pull(pullFlags)
 }
 
@@ -47,7 +75,7 @@ export async function getThemesByIdentifier(
   theme: string | undefined,
 ): Promise<Theme[]> {
   let storeThemes = await fetchStoreThemes(store, password)
-  const filter = new Filter({theme: theme})
+  const filter = new Filter({ theme: theme })
 
   if (filter.any()) {
     storeThemes = filterByTheme(storeThemes, filter)


### PR DESCRIPTION
In this PR, I fix the bug that prevents a `-t` flag from being passed and downloading settings from a specific theme.

Replace `pullThemeSettings` with `downloadThemeSettings` function that accepts `DownloadFlags` interface. Simplify command by removing manual flag mapping and add comprehensive test coverage for flag transformation and live theme default logic.