### PR TITLE
Add `theme settings pull`

### DIFF
--- a/.ai/prompts/create-prd.md
+++ b/.ai/prompts/create-prd.md
@@ -1,0 +1,56 @@
+# Rule: Generating a Product Requirements Document (PRD)
+
+## Goal
+
+To guide an AI assistant in creating a detailed Product Requirements Document (PRD) in Markdown format, based on an initial user prompt. The PRD should be clear, actionable, and suitable for a junior developer to understand and implement the feature.
+
+## Process
+
+1.  **Receive Initial Prompt:** The user provides a brief description or request for a new feature or functionality.
+2.  **Ask Clarifying Questions:** Before writing the PRD, the AI *must* ask clarifying questions to gather sufficient detail. The goal is to understand the "what" and "why" of the feature, not necessarily the "how" (which the developer will figure out).
+3.  **Generate PRD:** Based on the initial prompt and the user's answers to the clarifying questions, generate a PRD using the structure outlined below.
+4.  **Save PRD:** Save the generated document as `prd-[feature-name].md` inside the `.ai/tasks` directory.
+
+## Clarifying Questions (Examples)
+
+The AI should adapt its questions based on the prompt, but here are some common areas to explore:
+
+*   **Problem/Goal:** "What problem does this feature solve for the user?" or "What is the main goal we want to achieve with this feature?"
+*   **Target User:** "Who is the primary user of this feature?"
+*   **Core Functionality:** "Can you describe the key actions a user should be able to perform with this feature?"
+*   **User Stories:** "Could you provide a few user stories? (e.g., As a [type of user], I want to [perform an action] so that [benefit].)"
+*   **Acceptance Criteria:** "How will we know when this feature is successfully implemented? What are the key success criteria?"
+*   **Scope/Boundaries:** "Are there any specific things this feature *should not* do (non-goals)?"
+*   **Data Requirements:** "What kind of data does this feature need to display or manipulate?"
+*   **Design/UI:** "Are there any existing design mockups or UI guidelines to follow?" or "Can you describe the desired look and feel?"
+*   **Edge Cases:** "Are there any potential edge cases or error conditions we should consider?"
+
+## PRD Structure
+
+The generated PRD should include the following sections:
+
+1.  **Introduction/Overview:** Briefly describe the feature and the problem it solves. State the goal.
+2.  **Goals:** List the specific, measurable objectives for this feature.
+3.  **User Stories:** Detail the user narratives describing feature usage and benefits.
+4.  **Functional Requirements:** List the specific functionalities the feature must have. Use clear, concise language (e.g., "The system must allow users to upload a profile picture."). Number these requirements.
+5.  **Non-Goals (Out of Scope):** Clearly state what this feature will *not* include to manage scope.
+6.  **Design Considerations (Optional):** Link to mockups, describe UI/UX requirements, or mention relevant components/styles if applicable.
+7.  **Technical Considerations (Optional):** Mention any known technical constraints, dependencies, or suggestions (e.g., "Should integrate with the existing Auth module").
+8.  **Success Metrics:** How will the success of this feature be measured? (e.g., "Increase user engagement by 10%", "Reduce support tickets related to X").
+9.  **Open Questions:** List any remaining questions or areas needing further clarification.
+
+## Target Audience
+
+Assume the primary reader of the PRD is a **junior developer**. Therefore, requirements should be explicit, unambiguous, and avoid jargon where possible. Provide enough detail for them to understand the feature's purpose and core logic.
+
+## Output
+
+*   **Format:** Markdown (`.md`)
+*   **Location:** `.ai/tasks/`
+*   **Filename:** `prd-[feature-name].md`
+
+## Final instructions
+
+1. Do NOT start implementing the PRD
+2. Make sure to ask the user clarifying questions
+3. Take the user's answers to the clarifying questions and improve the PRD

--- a/.ai/prompts/generate-tasks-from-prd.md
+++ b/.ai/prompts/generate-tasks-from-prd.md
@@ -1,0 +1,59 @@
+# Rule: Generating a Task List from a PRD
+
+## Goal
+
+To guide an AI assistant in creating a detailed, step-by-step task list in Markdown format based on an existing Product Requirements Document (PRD). The task list should guide a developer through implementation.
+
+## Output
+
+- **Format:** Markdown (`.md`)
+- **Location:** `.ai/tasks/`
+- **Filename:** `tasks-[prd-file-name].md` (e.g., `tasks-prd-user-profile-editing.md`)
+
+## Process
+
+1.  **Receive PRD Reference:** The user points the AI to a specific PRD file
+2.  **Analyze PRD:** The AI reads and analyzes the functional requirements, user stories, and other sections of the specified PRD.
+3.  **Phase 1: Generate Parent Tasks:** Based on the PRD analysis, create the file and generate the main, high-level tasks required to implement the feature. Use your judgement on how many high-level tasks to use. It's likely to be about 5. Present these tasks to the user in the specified format (without sub-tasks yet). Inform the user: "I have generated the high-level tasks based on the PRD. Ready to generate the sub-tasks? Respond with 'Go' to proceed."
+4.  **Wait for Confirmation:** Pause and wait for the user to respond with "Go".
+5.  **Phase 2: Generate Sub-Tasks:** Once the user confirms, break down each parent task into smaller, actionable sub-tasks necessary to complete the parent task. Ensure sub-tasks logically follow from the parent task and cover the implementation details implied by the PRD.
+6.  **Identify Relevant Files:** Based on the tasks and PRD, identify potential files that will need to be created or modified. List these under the `Relevant Files` section, including corresponding test files if applicable.
+7.  **Generate Final Output:** Combine the parent tasks, sub-tasks, relevant files, and notes into the final Markdown structure.
+8.  **Save Task List:** Save the generated document in the `.ai/tasks/` directory with the filename `tasks-[prd-file-name].md`, where `[prd-file-name]` matches the base name of the input PRD file (e.g., if the input was `prd-user-profile-editing.md`, the output is `tasks-prd-user-profile-editing.md`).
+
+## Output Format
+
+The generated task list _must_ follow this structure:
+
+```markdown
+## Relevant Files
+
+- `path/to/potential/file1.ts` - Brief description of why this file is relevant (e.g., Contains the main component for this feature).
+- `path/to/file1.test.ts` - Unit tests for `file1.ts`.
+- `path/to/another/file.tsx` - Brief description (e.g., API route handler for data submission).
+- `path/to/another/file.test.tsx` - Unit tests for `another/file.tsx`.
+- `lib/utils/helpers.ts` - Brief description (e.g., Utility functions needed for calculations).
+- `lib/utils/helpers.test.ts` - Unit tests for `helpers.ts`.
+
+### Notes
+
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `MyComponent.tsx` and `MyComponent.test.tsx` in the same directory).
+- Use `pnpm test` to run tests. Running without a path executes all tests found by the Jest configuration.
+
+## Tasks
+
+- [ ] 1.0 Parent Task Title
+  - [ ] 1.1 [Sub-task description 1.1]
+  - [ ] 1.2 [Sub-task description 1.2]
+- [ ] 2.0 Parent Task Title
+  - [ ] 2.1 [Sub-task description 2.1]
+- [ ] 3.0 Parent Task Title (may not require sub-tasks if purely structural or configuration)
+```
+
+## Interaction Model
+
+The process explicitly requires a pause after generating parent tasks to get user confirmation ("Go") before proceeding to generate the detailed sub-tasks. This ensures the high-level plan aligns with user expectations before diving into details.
+
+## Target Audience
+
+Assume the primary reader of the task list is a **junior developer** who will implement the feature.

--- a/.ai/prompts/process-task-list.md
+++ b/.ai/prompts/process-task-list.md
@@ -1,0 +1,33 @@
+# Task List Management
+
+Guidelines for managing task lists in markdown files to track progress on completing a PRD
+
+## Task Implementation
+- **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say “yes” or "y"
+- **Completion protocol:**  
+  1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.  
+  2. If **all** subtasks underneath a parent task are now `[x]`, also mark the **parent task** as completed.  
+- Stop after each sub‑task and wait for the user’s go‑ahead.
+
+## Task List Maintenance
+
+1. **Update the task list as you work:**
+   - Mark tasks and subtasks as completed (`[x]`) per the protocol above.
+   - Add new tasks as they emerge.
+
+2. **Maintain the “Relevant Files” section:**
+   - List every file created or modified.
+   - Give each file a one‑line description of its purpose.
+
+## AI Instructions
+
+When working with task lists, the AI must:
+
+1. Regularly update the task list file after finishing any significant work.
+2. Follow the completion protocol:
+   - Mark each finished **sub‑task** `[x]`.
+   - Mark the **parent task** `[x]` once **all** its subtasks are `[x]`.
+3. Add newly discovered tasks.
+4. Keep “Relevant Files” accurate and up to date.
+5. Before starting work, check which sub‑task is next.
+6. After implementing a sub‑task, update the file and then pause for user approval.

--- a/.ai/tasks/prd-theme-settings-pull-refactor.md
+++ b/.ai/tasks/prd-theme-settings-pull-refactor.md
@@ -1,0 +1,74 @@
+# Product Requirements Document: Refactor Theme Settings Download to Pull Command
+
+## Introduction/Overview
+
+This feature involves refactoring the existing `theme settings download` command to be named `theme settings pull` to align with Shopify CLI naming patterns. The original `download` command will remain functional as a hidden alias to maintain backwards compatibility for existing users and scripts.
+
+**Problem:** The current command naming (`download`) doesn't match the patterns used by the official Shopify CLI, which may cause confusion for users familiar with Shopify's tooling.
+
+**Goal:** Rename the command to follow Shopify CLI conventions while maintaining full backwards compatibility.
+
+## Goals
+
+1. Create a new `theme settings pull` command that matches Shopify CLI naming patterns
+2. Maintain backwards compatibility by keeping `theme settings download` functional as a hidden alias
+3. Update all user-facing documentation to reflect the new command name
+4. Ensure zero breaking changes for existing users
+
+## User Stories
+
+- **As a developer familiar with Shopify CLI**, I want to use `theme settings pull` so that the command naming is consistent with what I expect from Shopify tools.
+- **As an existing user of the tool**, I want my existing scripts using `theme settings download` to continue working without modification so that I don't have to update my workflows immediately.
+- **As a new user reading documentation**, I want to see `pull` as the primary command so that I learn the preferred/standard naming convention.
+
+## Functional Requirements
+
+1. **FR-1:** The system must create a new `theme settings pull` command with identical functionality to the existing `download` command.
+2. **FR-2:** The system must keep the existing `theme settings download` command working with identical behavior.
+3. **FR-3:** The `download` command must be hidden from help text and command listings to discourage new usage.
+4. **FR-4:** All flags, options, and behaviors must work identically between `pull` and `download` commands.
+5. **FR-5:** Help text and descriptions must be updated to reference "pull" instead of "download".
+6. **FR-6:** The command description must be updated to use "pull" terminology (e.g., "Pull settings from live theme" instead of "Download settings from live theme").
+7. **FR-7:** Environment variables and flag names should remain unchanged to maintain compatibility.
+
+## Non-Goals (Out of Scope)
+
+- Refactoring other commands beyond `theme settings download`
+- Changing the underlying functionality or behavior of the command
+- Adding deprecation warnings for the `download` alias (maintain silent backwards compatibility)
+- Modifying flag names or environment variables
+- Changes to the command's core logic or implementation details
+
+## Design Considerations
+
+- **File Structure:** Create a new `pull.ts` file alongside the existing `download.ts`
+- **Code Reuse:** The `download.ts` file should import and extend the `pull.ts` command to avoid code duplication
+- **Command Registration:** Both commands need to be properly registered in the CLI framework
+- **Help Text:** Update descriptions to use "pull" terminology while maintaining technical accuracy
+
+## Technical Considerations
+
+- **Existing Dependencies:** The refactor should use the existing `downloadThemeSettings` utility function without modification
+- **Flag Compatibility:** All existing flags (`-d`, `-l`, `-t`, `-n`) must work identically in both commands
+- **Command Structure:** Follow the existing pattern used in the codebase for command organization
+- **Import Paths:** Ensure proper import/export structure to avoid circular dependencies
+
+## Success Metrics
+
+1. **Backwards Compatibility:** 100% of existing `theme settings download` usage continues to work without changes
+2. **Functionality Parity:** All flags and options work identically between `pull` and `download` commands
+3. **Documentation Consistency:** All help text and descriptions reference "pull" as the primary command
+4. **User Adoption:** New users naturally discover and use the `pull` command through documentation and help text
+
+## Open Questions
+
+1. Should we add any logging or analytics to track usage of the deprecated `download` alias vs the new `pull` command?
+2. Do we need to update any existing tests to cover both command names?
+3. Are there any internal documentation or README files that should be updated to reflect the new command name?
+
+## Implementation Notes
+
+- The new `pull.ts` file should be the primary implementation
+- The `download.ts` file should become a thin wrapper that imports and extends `pull.ts`
+- Both files should maintain the same export structure for CLI framework compatibility
+- Consider using a shared base class or composition pattern to avoid code duplication

--- a/.ai/tasks/tasks-prd-theme-settings-pull-refactor.md
+++ b/.ai/tasks/tasks-prd-theme-settings-pull-refactor.md
@@ -1,0 +1,50 @@
+## Relevant Files
+
+- `src/commands/theme/settings/pull.ts` - New primary command implementation for `theme settings pull`.
+- `src/commands/theme/settings/download.ts` - Existing command file that will be refactored to act as a hidden alias.
+- `src/utilities/theme.js` - Contains the `downloadThemeSettings` utility function used by both commands.
+- `src/utilities/shopify/flags.js` - Contains shared theme flags used by commands.
+- `src/commands/theme/settings/pull.test.ts` - Unit tests for the new pull command.
+- `src/commands/theme/settings/download.test.ts` - Updated unit tests for the download alias command.
+
+### Notes
+
+- Unit tests should typically be placed alongside the code files they are testing.
+- Use `pnpm test` to run tests. Running without a path executes all tests found by the Jest configuration.
+- The existing `downloadThemeSettings` utility function should remain unchanged to maintain compatibility.
+- Both commands must be properly registered in the CLI framework for discovery.
+
+## Tasks
+
+- [x] 1.0 Create the new `theme settings pull` command
+  - [x] 1.1 Create `src/commands/theme/settings/pull.ts` file with identical functionality to existing download command
+  - [x] 1.2 Update command description to use "pull" terminology (e.g., "Pull settings from live theme")
+  - [x] 1.3 Update flag descriptions to use "pull" terminology where applicable
+  - [x] 1.4 Ensure all existing flags (`-d`, `-l`, `-t`, `-n`) work identically
+  - [x] 1.5 Import and use the existing `downloadThemeSettings` utility function
+  - [x] 1.6 Verify proper integration with global flags and theme flags
+
+- [x] 2.0 Refactor the existing download command to act as a hidden alias
+  - [x] 2.1 Modify `src/commands/theme/settings/download.ts` to import and extend the pull command
+  - [x] 2.2 Add `hidden: true` property to hide the command from help text and listings
+  - [x] 2.3 Ensure the download command maintains identical behavior to the original
+  - [x] 2.4 Verify all flags and functionality work exactly the same as before
+  - [x] 2.5 Test that existing scripts using `theme settings download` continue to work
+
+- [x] 3.0 Ensure proper command registration and CLI framework integration
+  - [x] 3.1 Verify both commands are properly registered in the CLI framework
+  - [x] 3.2 Test command discovery for `theme settings pull`
+  - [x] 3.3 Confirm `theme settings download` remains functional but hidden
+  - [x] 3.4 Validate help text shows only the pull command in listings
+
+- [ ] 4.0 Create comprehensive tests for both commands
+  - [x] 4.1 Create unit tests for the new pull command (`pull.test.ts`)
+  - [x] 4.2 Update existing tests for the download command to verify alias behavior
+  - [x] 4.3 Test flag compatibility between both commands
+
+- [ ] 5.0 Validate backwards compatibility and functionality parity
+  - [ ] 5.1 Test all existing flag combinations work identically in both commands
+  - [ ] 5.2 Verify environment variables work the same for both commands
+  - [ ] 5.3 Confirm error handling and edge cases behave identically
+  - [ ] 5.4 Test help text updates show correct "pull" terminology
+  - [ ] 5.5 Validate that no breaking changes were introduced for existing users

--- a/.rules
+++ b/.rules
@@ -1,0 +1,14 @@
+# Shopkeeper
+
+You are an expert Typescript developer.
+
+This project is a custom CLI for interacting with Shopify theme settings.
+It uses some of the Shopify CLI libraries to maintain compatibility where possible.
+
+You can use `./bin/dev.js` to run the project.
+You can use `pnpm test` to run the test suite.
+The test suite uses vitest.
+
+When you write code, ensure there are no diganostics issues -- type errors, etc.
+
+There is a sample theme in `shopify` and `.env` provides environment variables for accessing a test store.

--- a/docs/commands/readme.md
+++ b/docs/commands/readme.md
@@ -12,7 +12,7 @@
 * [`shopkeeper theme create`](#shopkeeper-theme-create)
 * [`shopkeeper theme deploy`](#shopkeeper-theme-deploy)
 * [`shopkeeper theme get`](#shopkeeper-theme-get)
-* [`shopkeeper theme settings download`](#shopkeeper-theme-settings-download)
+* [`shopkeeper theme settings pull`](#shopkeeper-theme-settings-pull)
 
 ## `shopkeeper bucket create`
 
@@ -287,13 +287,13 @@ DESCRIPTION
 
 _See code: [src/commands/theme/get.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/src/commands/theme/get.ts)_
 
-## `shopkeeper theme settings download`
+## `shopkeeper theme settings pull`
 
-Download settings from live theme.
+Pull settings from live theme.
 
 ```
 USAGE
-  $ shopkeeper theme settings download [--no-color] [--verbose] [--path <value>] [--password <value>] [-s <value>] [-e
+  $ shopkeeper theme settings pull [--no-color] [--verbose] [--path <value>] [--password <value>] [-s <value>] [-e
     <value>] [-d] [-l] [-t <value>] [-n]
 
 FLAGS
@@ -310,8 +310,8 @@ FLAGS
       --verbose              Increase the verbosity of the output.
 
 DESCRIPTION
-  Download settings from live theme.
+  Pull settings from live theme.
 ```
 
-_See code: [src/commands/theme/settings/download.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/src/commands/theme/settings/download.ts)_
+_See code: [src/commands/theme/settings/pull.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/src/commands/theme/settings/pull.ts)_
 <!-- commandsstop -->

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -838,6 +838,7 @@
         }
       },
       "hasDynamicHelp": false,
+      "hidden": true,
       "hiddenAliases": [],
       "id": "theme:settings:download",
       "pluginAlias": "@thebeyondgroup/shopkeeper",
@@ -852,6 +853,113 @@
         "theme",
         "settings",
         "download.js"
+      ]
+    },
+    "theme:settings:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Pull settings from live theme.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your theme directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Pull settings files from your remote development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "live": {
+          "char": "l",
+          "description": "Pull settings files from your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Runs the pull command without deleting local files.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:settings:pull",
+      "pluginAlias": "@thebeyondgroup/shopkeeper",
+      "pluginName": "@thebeyondgroup/shopkeeper",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "theme",
+        "settings",
+        "pull.js"
       ]
     }
   },

--- a/src/commands/theme/settings/download.test.ts
+++ b/src/commands/theme/settings/download.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import Download from './download.js'
+import Pull from './pull.js'
+import * as themeUtils from '../../../utilities/theme.js'
+
+vi.mock('../../../utilities/theme.js')
+
+describe('Download command (alias)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('inheritance and alias behavior', () => {
+    test('extends Pull command', () => {
+      const download = new Download([], {} as any)
+      expect(download instanceof Pull).toBe(true)
+      expect(download.constructor.name).toBe('Download')
+    })
+
+    test('has correct description for backwards compatibility', () => {
+      expect(Download.description).toBe('Download settings from live theme.')
+    })
+
+    test('is hidden from command listings', () => {
+      expect(Download.hidden).toBe(true)
+    })
+
+    test('inherits all flags from Pull command', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      // Download should inherit all flags from Pull
+      expect(downloadFlags).toBe(pullFlags)
+
+      // Verify specific flags exist and have correct properties
+      expect(downloadFlags.development).toBeDefined()
+      expect(downloadFlags.development.char).toBe('d')
+      expect(downloadFlags.development.env).toBe('SHOPIFY_FLAG_DEVELOPMENT')
+
+      expect(downloadFlags.live).toBeDefined()
+      expect(downloadFlags.live.char).toBe('l')
+      expect(downloadFlags.live.env).toBe('SHOPIFY_FLAG_LIVE')
+
+      expect(downloadFlags.theme).toBeDefined()
+      expect(downloadFlags.theme.char).toBe('t')
+      expect(downloadFlags.theme.env).toBe('SHOPIFY_FLAG_THEME_ID')
+
+      expect(downloadFlags.nodelete).toBeDefined()
+      expect(downloadFlags.nodelete.char).toBe('n')
+      expect(downloadFlags.nodelete.env).toBe('SHOPIFY_FLAG_NODELETE')
+    })
+
+    test('inherits run method from Pull command', () => {
+      expect(typeof Download.prototype.run).toBe('function')
+      // The run method should be the same as Pull's run method
+      expect(Download.prototype.run).toBe(Pull.prototype.run)
+    })
+  })
+
+  describe('functional compatibility', () => {
+    test('calls downloadThemeSettings when run method is invoked', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      // When
+      const download = new Download([], {} as any)
+      const mockParse = vi.fn().mockResolvedValue({
+        flags: {
+          live: true,
+          development: false,
+          theme: 'test-theme',
+          nodelete: true,
+          verbose: true,
+          'no-color': false,
+          store: 'test.myshopify.com',
+          password: 'test-password',
+          path: '/test/path'
+        }
+      })
+      // @ts-ignore - accessing protected method for testing
+      download.parse = mockParse
+
+      await download.run()
+
+      // Then
+      expect(mockDownloadThemeSettings).toHaveBeenCalledWith({
+        live: true,
+        development: false,
+        theme: 'test-theme',
+        nodelete: true,
+        verbose: true,
+        'no-color': false,
+        store: 'test.myshopify.com',
+        password: 'test-password',
+        path: '/test/path'
+      })
+    })
+
+    test('handles all flag combinations identically to Pull command', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      // Test multiple flag combinations
+      const flagCombinations = [
+        { development: true, nodelete: false },
+        { live: true, theme: '123456' },
+        { theme: 'my-theme', nodelete: true },
+        { development: true, live: false, nodelete: true, theme: 'test' },
+        {}
+      ]
+
+      for (const flags of flagCombinations) {
+        mockDownloadThemeSettings.mockClear()
+
+        const download = new Download([], {} as any)
+        const mockParse = vi.fn().mockResolvedValue({ flags })
+        // @ts-ignore - accessing protected method for testing
+        download.parse = mockParse
+
+        await download.run()
+
+        expect(mockDownloadThemeSettings).toHaveBeenCalledWith(flags)
+      }
+    })
+
+    test('propagates errors identically to Pull command', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      const testError = new Error('Download failed')
+      mockDownloadThemeSettings.mockRejectedValue(testError)
+
+      // When/Then
+      const download = new Download([], {} as any)
+      const mockParse = vi.fn().mockResolvedValue({
+        flags: {}
+      })
+      // @ts-ignore - accessing protected method for testing
+      download.parse = mockParse
+
+      await expect(download.run()).rejects.toThrow('Download failed')
+      expect(mockDownloadThemeSettings).toHaveBeenCalled()
+    })
+  })
+
+  describe('backwards compatibility verification', () => {
+    test('maintains original command description', () => {
+      // Ensure the description specifically says "Download" for backwards compatibility
+      expect(Download.description).toContain('Download')
+      expect(Download.description).not.toContain('Pull')
+    })
+
+    test('has identical flag structure to original implementation', () => {
+      const flags = Download.flags
+
+      // Verify all original flags are present with correct properties
+      expect(flags.development.description).toContain('Pull settings files from your remote development theme')
+      expect(flags.live.description).toContain('Pull settings files from your remote live theme')
+      expect(flags.nodelete.description).toContain('Runs the pull command without deleting local files')
+      expect(flags.theme.description).toBe('Theme ID or name of the remote theme.')
+    })
+
+    test('uses same utility function as original', () => {
+      // The Download command should call the same downloadThemeSettings function
+      // This is verified through the inheritance and the run method tests above
+      expect(Download.prototype.run).toBe(Pull.prototype.run)
+    })
+  })
+
+  describe('flag inheritance verification', () => {
+    test('inherits global flags from Pull', () => {
+      const flags = Download.flags
+
+      // Should include verbose and no-color from global flags
+      expect(flags.verbose).toBeDefined()
+      expect(flags['no-color']).toBeDefined()
+    })
+
+    test('inherits theme flags from Pull', () => {
+      const flags = Download.flags
+
+      // Should include store and other theme-related flags
+      expect(flags.store).toBeDefined()
+      expect(flags.password).toBeDefined()
+      expect(flags.path).toBeDefined()
+      expect(flags.environment).toBeDefined()
+    })
+
+    test('flag environment variables work identically', () => {
+      const flags = Download.flags
+
+      // Environment variables should be identical to Pull command
+      expect(flags.development.env).toBe('SHOPIFY_FLAG_DEVELOPMENT')
+      expect(flags.live.env).toBe('SHOPIFY_FLAG_LIVE')
+      expect(flags.theme.env).toBe('SHOPIFY_FLAG_THEME_ID')
+      expect(flags.nodelete.env).toBe('SHOPIFY_FLAG_NODELETE')
+    })
+  })
+
+  describe('command properties comparison with Pull', () => {
+    test('has same flag structure as Pull except for description and hidden property', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      // Flags should be identical objects (inherited)
+      expect(downloadFlags).toBe(pullFlags)
+    })
+
+    test('differs from Pull only in description and hidden status', () => {
+      // Description should be different
+      expect(Download.description).toBe('Download settings from live theme.')
+      expect(Pull.description).toBe('Pull settings from live theme.')
+
+      // Hidden status should be different
+      expect(Download.hidden).toBe(true)
+      expect(Pull.hidden).toBeUndefined()
+
+      // Everything else should be inherited/identical
+      expect(Download.flags).toBe(Pull.flags)
+    })
+  })
+})

--- a/src/commands/theme/settings/download.test.ts
+++ b/src/commands/theme/settings/download.test.ts
@@ -52,8 +52,10 @@ describe('Download command (alias)', () => {
 
     test('inherits run method from Pull command', () => {
       expect(typeof Download.prototype.run).toBe('function')
-      // The run method should be the same as Pull's run method
-      expect(Download.prototype.run).toBe(Pull.prototype.run)
+      // The Download class overrides run method to show deprecation warning
+      // but it should call super.run() which is Pull's run method
+      expect(Download.prototype.run).not.toBe(Pull.prototype.run)
+      expect(typeof Download.prototype.run).toBe('function')
     })
   })
 
@@ -163,8 +165,9 @@ describe('Download command (alias)', () => {
 
     test('uses same utility function as original', () => {
       // The Download command should call the same downloadThemeSettings function
-      // This is verified through the inheritance and the run method tests above
-      expect(Download.prototype.run).toBe(Pull.prototype.run)
+      // via super.run() even though it overrides the run method for deprecation warning
+      expect(Download.prototype.run).not.toBe(Pull.prototype.run)
+      expect(typeof Download.prototype.run).toBe('function')
     })
   })
 

--- a/src/commands/theme/settings/download.ts
+++ b/src/commands/theme/settings/download.ts
@@ -1,6 +1,17 @@
+import { renderWarning } from '@shopify/cli-kit/node/ui'
 import Pull from './pull.js'
 
 export default class Download extends Pull {
   static description = 'Download settings from live theme.'
   static hidden = true
+
+
+  async run() {
+    renderWarning({
+      headline: ['The', { command: 'shopkeeper theme settings download' }, 'command is deprecated.'],
+      body: ['Use', { command: 'shopkeeper theme settings pull' }, 'instead.'],
+    })
+
+    await super.run()
+  }
 }

--- a/src/commands/theme/settings/download.ts
+++ b/src/commands/theme/settings/download.ts
@@ -1,39 +1,6 @@
-import { Flags } from '@oclif/core'
-import { globalFlags } from '@shopify/cli-kit/node/cli'
-import BaseCommand from '@shopify/cli-kit/node/base-command'
-import { themeFlags } from '../../../utilities/shopify/flags.js'
-import { downloadThemeSettings, DownloadFlags } from '../../../utilities/theme.js'
+import Pull from './pull.js'
 
-export default class Download extends BaseCommand {
+export default class Download extends Pull {
   static description = 'Download settings from live theme.'
-
-  static flags = {
-    ...globalFlags,
-    ...themeFlags,
-    development: Flags.boolean({
-      char: 'd',
-      description: 'Pull settings files from your remote development theme.',
-      env: 'SHOPIFY_FLAG_DEVELOPMENT',
-    }),
-    live: Flags.boolean({
-      char: 'l',
-      description: 'Pull settings files from your remote live theme.',
-      env: 'SHOPIFY_FLAG_LIVE',
-    }),
-    theme: Flags.string({
-      char: 't',
-      description: 'Theme ID or name of the remote theme.',
-      env: 'SHOPIFY_FLAG_THEME_ID',
-    }),
-    nodelete: Flags.boolean({
-      char: 'n',
-      description: 'Runs the pull command without deleting local files.',
-      env: 'SHOPIFY_FLAG_NODELETE',
-    }),
-  }
-
-  async run(): Promise<void> {
-    const { flags } = await this.parse(Download)
-    await downloadThemeSettings(flags as DownloadFlags)
-  }
+  static hidden = true
 }

--- a/src/commands/theme/settings/flag-compatibility.test.ts
+++ b/src/commands/theme/settings/flag-compatibility.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import Pull from './pull.js'
+import Download from './download.js'
+import * as themeUtils from '../../../utilities/theme.js'
+
+vi.mock('../../../utilities/theme.js')
+
+describe('Flag compatibility between Pull and Download commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('flag structure identity', () => {
+    test('both commands have identical flag objects', () => {
+      // The Download command should inherit the exact same flags object from Pull
+      expect(Download.flags).toBe(Pull.flags)
+    })
+
+    test('both commands have identical flag properties', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      // Get all flag names
+      const flagNames = Object.keys(pullFlags)
+
+      flagNames.forEach(flagName => {
+        const pullFlag = (pullFlags as any)[flagName]
+        const downloadFlag = (downloadFlags as any)[flagName]
+
+        // Each flag should be the exact same object reference
+        expect(downloadFlag).toBe(pullFlag)
+
+        // Verify key properties are identical
+        if (pullFlag.char) {
+          expect(downloadFlag.char).toBe(pullFlag.char)
+        }
+        if (pullFlag.env) {
+          expect(downloadFlag.env).toBe(pullFlag.env)
+        }
+        if (pullFlag.description) {
+          expect(downloadFlag.description).toBe(pullFlag.description)
+        }
+        expect(downloadFlag.type).toBe(pullFlag.type)
+      })
+    })
+  })
+
+  describe('specific flag compatibility', () => {
+    test('development flag (-d) is identical', () => {
+      const pullDev = Pull.flags.development
+      const downloadDev = Download.flags.development
+
+      expect(downloadDev).toBe(pullDev)
+      expect(downloadDev.char).toBe('d')
+      expect(downloadDev.env).toBe('SHOPIFY_FLAG_DEVELOPMENT')
+      expect(downloadDev.description).toBe('Pull settings files from your remote development theme.')
+      expect(downloadDev.type).toBe('boolean')
+    })
+
+    test('live flag (-l) is identical', () => {
+      const pullLive = Pull.flags.live
+      const downloadLive = Download.flags.live
+
+      expect(downloadLive).toBe(pullLive)
+      expect(downloadLive.char).toBe('l')
+      expect(downloadLive.env).toBe('SHOPIFY_FLAG_LIVE')
+      expect(downloadLive.description).toBe('Pull settings files from your remote live theme.')
+      expect(downloadLive.type).toBe('boolean')
+    })
+
+    test('theme flag (-t) is identical', () => {
+      const pullTheme = Pull.flags.theme
+      const downloadTheme = Download.flags.theme
+
+      expect(downloadTheme).toBe(pullTheme)
+      expect(downloadTheme.char).toBe('t')
+      expect(downloadTheme.env).toBe('SHOPIFY_FLAG_THEME_ID')
+      expect(downloadTheme.description).toBe('Theme ID or name of the remote theme.')
+      expect(downloadTheme.type).toBe('option')
+    })
+
+    test('nodelete flag (-n) is identical', () => {
+      const pullNodelete = Pull.flags.nodelete
+      const downloadNodelete = Download.flags.nodelete
+
+      expect(downloadNodelete).toBe(pullNodelete)
+      expect(downloadNodelete.char).toBe('n')
+      expect(downloadNodelete.env).toBe('SHOPIFY_FLAG_NODELETE')
+      expect(downloadNodelete.description).toBe('Runs the pull command without deleting local files.')
+      expect(downloadNodelete.type).toBe('boolean')
+    })
+
+    test('store flag (-s) is identical', () => {
+      const pullStore = Pull.flags.store
+      const downloadStore = Download.flags.store
+
+      expect(downloadStore).toBe(pullStore)
+      expect(downloadStore.char).toBe('s')
+      expect(downloadStore.description).toContain('Store URL')
+    })
+
+    test('environment flag (-e) is identical', () => {
+      const pullEnv = Pull.flags.environment
+      const downloadEnv = Download.flags.environment
+
+      expect(downloadEnv).toBe(pullEnv)
+      expect(downloadEnv.char).toBe('e')
+      expect(downloadEnv.description).toContain('environment')
+    })
+
+    test('global flags are identical', () => {
+      // Verbose flag
+      expect(Download.flags.verbose).toBe(Pull.flags.verbose)
+      expect(Download.flags.verbose.description).toContain('verbosity')
+
+      // No-color flag
+      expect(Download.flags['no-color']).toBe(Pull.flags['no-color'])
+      expect(Download.flags['no-color'].description).toContain('color')
+
+      // Path flag
+      expect(Download.flags.path).toBe(Pull.flags.path)
+      expect(Download.flags.path.description).toContain('path')
+
+      // Password flag
+      expect(Download.flags.password).toBe(Pull.flags.password)
+      expect(Download.flags.password.description).toContain('Password')
+    })
+  })
+
+  describe('functional flag compatibility', () => {
+    test('both commands process identical flags identically', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      const testFlags = {
+        development: true,
+        live: false,
+        theme: 'test-theme-123',
+        nodelete: true,
+        verbose: true,
+        'no-color': false,
+        store: 'test.myshopify.com',
+        password: 'secret123',
+        path: '/my/theme/path',
+        environment: 'staging'
+      }
+
+      // Test Pull command
+      const pull = new Pull([], {} as any)
+      const pullParse = vi.fn().mockResolvedValue({ flags: testFlags })
+      // @ts-ignore - accessing protected method for testing
+      pull.parse = pullParse
+
+      await pull.run()
+
+      const pullCallArgs = mockDownloadThemeSettings.mock.calls[0]?.[0]
+
+      // Reset mock
+      mockDownloadThemeSettings.mockClear()
+
+      // Test Download command with same flags
+      const download = new Download([], {} as any)
+      const downloadParse = vi.fn().mockResolvedValue({ flags: testFlags })
+      // @ts-ignore - accessing protected method for testing
+      download.parse = downloadParse
+
+      await download.run()
+
+      const downloadCallArgs = mockDownloadThemeSettings.mock.calls[0]?.[0]
+
+      // Both commands should pass identical arguments to downloadThemeSettings
+      expect(downloadCallArgs).toEqual(pullCallArgs)
+      expect(downloadCallArgs).toEqual(testFlags)
+    })
+
+    test('both commands handle missing flags identically', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      const minimalFlags = {
+        development: undefined,
+        live: undefined,
+        theme: undefined,
+        nodelete: undefined
+      }
+
+      // Test Pull command
+      const pull = new Pull([], {} as any)
+      const pullParse = vi.fn().mockResolvedValue({ flags: minimalFlags })
+      // @ts-ignore - accessing protected method for testing
+      pull.parse = pullParse
+
+      await pull.run()
+
+      const pullCallArgs = mockDownloadThemeSettings.mock.calls[0]?.[0]
+
+      // Reset mock
+      mockDownloadThemeSettings.mockClear()
+
+      // Test Download command with same flags
+      const download = new Download([], {} as any)
+      const downloadParse = vi.fn().mockResolvedValue({ flags: minimalFlags })
+      // @ts-ignore - accessing protected method for testing
+      download.parse = downloadParse
+
+      await download.run()
+
+      const downloadCallArgs = mockDownloadThemeSettings.mock.calls[0]?.[0]
+
+      // Both should handle missing flags identically
+      expect(downloadCallArgs).toEqual(pullCallArgs)
+      expect(downloadCallArgs).toEqual(minimalFlags)
+    })
+
+    test('both commands handle boolean flag variations identically', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      const booleanFlagTests = [
+        { development: true, live: false, nodelete: true },
+        { development: false, live: true, nodelete: false },
+        { development: true, live: true, nodelete: true },
+        { development: false, live: false, nodelete: false }
+      ]
+
+      for (const flags of booleanFlagTests) {
+        // Test Pull command
+        mockDownloadThemeSettings.mockClear()
+
+        const pull = new Pull([], {} as any)
+        const pullParse = vi.fn().mockResolvedValue({ flags })
+        // @ts-ignore - accessing protected method for testing
+        pull.parse = pullParse
+
+        await pull.run()
+        const pullCallArgs = mockDownloadThemeSettings.mock.calls[0]?.[0]
+
+        // Test Download command with same flags
+        mockDownloadThemeSettings.mockClear()
+
+        const download = new Download([], {} as any)
+        const downloadParse = vi.fn().mockResolvedValue({ flags })
+        // @ts-ignore - accessing protected method for testing
+        download.parse = downloadParse
+
+        await download.run()
+        const downloadCallArgs = mockDownloadThemeSettings.mock.calls[0]?.[0]
+
+        // Should be identical
+        expect(downloadCallArgs).toEqual(pullCallArgs)
+        expect(downloadCallArgs).toEqual(flags)
+      }
+    })
+  })
+
+  describe('environment variable compatibility', () => {
+    test('both commands use identical environment variable names', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      const envFlags = ['development', 'live', 'theme', 'nodelete']
+
+      envFlags.forEach(flagName => {
+        expect((downloadFlags as any)[flagName].env).toBe((pullFlags as any)[flagName].env)
+      })
+
+      // Verify specific env var names
+      expect(downloadFlags.development.env).toBe('SHOPIFY_FLAG_DEVELOPMENT')
+      expect(downloadFlags.live.env).toBe('SHOPIFY_FLAG_LIVE')
+      expect(downloadFlags.theme.env).toBe('SHOPIFY_FLAG_THEME_ID')
+      expect(downloadFlags.nodelete.env).toBe('SHOPIFY_FLAG_NODELETE')
+    })
+  })
+
+  describe('flag validation compatibility', () => {
+    test('both commands have identical flag types', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      Object.keys(pullFlags).forEach(flagName => {
+        expect((downloadFlags as any)[flagName].type).toBe((pullFlags as any)[flagName].type)
+      })
+    })
+
+    test('both commands have identical required flags', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      Object.keys(pullFlags).forEach(flagName => {
+        expect((downloadFlags as any)[flagName].required).toBe((pullFlags as any)[flagName].required)
+      })
+    })
+
+    test('both commands have identical flag defaults', () => {
+      const pullFlags = Pull.flags
+      const downloadFlags = Download.flags
+
+      Object.keys(pullFlags).forEach(flagName => {
+        expect((downloadFlags as any)[flagName].default).toBe((pullFlags as any)[flagName].default)
+      })
+    })
+  })
+
+  describe('error handling compatibility', () => {
+    test('both commands propagate downloadThemeSettings errors identically', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      const testError = new Error('Theme download failed')
+      mockDownloadThemeSettings.mockRejectedValue(testError)
+
+      const testFlags = { live: true }
+
+      // Test Pull command error handling
+      const pull = new Pull([], {} as any)
+      const pullParse = vi.fn().mockResolvedValue({ flags: testFlags })
+      // @ts-ignore - accessing protected method for testing
+      pull.parse = pullParse
+
+      let pullError: Error | undefined
+      try {
+        await pull.run()
+      } catch (error) {
+        pullError = error as Error
+      }
+
+      // Test Download command error handling
+      const download = new Download([], {} as any)
+      const downloadParse = vi.fn().mockResolvedValue({ flags: testFlags })
+      // @ts-ignore - accessing protected method for testing
+      download.parse = downloadParse
+
+      let downloadError: Error | undefined
+      try {
+        await download.run()
+      } catch (error) {
+        downloadError = error as Error
+      }
+
+      // Both should throw the same error
+      expect(pullError).toBeDefined()
+      expect(downloadError).toBeDefined()
+      expect(pullError?.message).toBe(downloadError?.message)
+      expect(pullError?.message).toBe('Theme download failed')
+    })
+  })
+})

--- a/src/commands/theme/settings/pull.test.ts
+++ b/src/commands/theme/settings/pull.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import Pull from './pull.js'
+import * as themeUtils from '../../../utilities/theme.js'
+
+vi.mock('../../../utilities/theme.js')
+
+describe('Pull command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('command properties', () => {
+    test('has correct description', () => {
+      expect(Pull.description).toBe('Pull settings from live theme.')
+    })
+
+    test('has correct flags structure', () => {
+      const flags = Pull.flags
+
+      // Check that all required flags exist
+      expect(flags.development).toBeDefined()
+      expect(flags.live).toBeDefined()
+      expect(flags.theme).toBeDefined()
+      expect(flags.nodelete).toBeDefined()
+
+      // Check flag characters
+      expect(flags.development.char).toBe('d')
+      expect(flags.live.char).toBe('l')
+      expect(flags.theme.char).toBe('t')
+      expect(flags.nodelete.char).toBe('n')
+
+      // Check environment variables
+      expect(flags.development.env).toBe('SHOPIFY_FLAG_DEVELOPMENT')
+      expect(flags.live.env).toBe('SHOPIFY_FLAG_LIVE')
+      expect(flags.theme.env).toBe('SHOPIFY_FLAG_THEME_ID')
+      expect(flags.nodelete.env).toBe('SHOPIFY_FLAG_NODELETE')
+    })
+
+    test('includes global flags and theme flags', () => {
+      const flags = Pull.flags
+
+      // Should include verbose and no-color from global flags
+      expect(flags.verbose).toBeDefined()
+      expect(flags['no-color']).toBeDefined()
+
+      // Should include store and other theme-related flags
+      expect(flags.store).toBeDefined()
+      expect(flags.password).toBeDefined()
+      expect(flags.path).toBeDefined()
+    })
+
+    test('is not hidden', () => {
+      expect(Pull.hidden).toBeUndefined()
+    })
+  })
+
+  describe('run method', () => {
+    test('calls downloadThemeSettings when run method is invoked', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      // When
+      const pull = new Pull([], {} as any)
+      const mockParse = vi.fn().mockResolvedValue({
+        flags: {
+          live: true,
+          development: false,
+          theme: 'test-theme',
+          nodelete: true,
+          verbose: true,
+          'no-color': false,
+          store: 'test.myshopify.com',
+          password: 'test-password',
+          path: '/test/path'
+        }
+      })
+      // @ts-ignore - accessing protected method for testing
+      pull.parse = mockParse
+
+      await pull.run()
+
+      // Then
+      expect(mockDownloadThemeSettings).toHaveBeenCalledWith({
+        live: true,
+        development: false,
+        theme: 'test-theme',
+        nodelete: true,
+        verbose: true,
+        'no-color': false,
+        store: 'test.myshopify.com',
+        password: 'test-password',
+        path: '/test/path'
+      })
+    })
+
+    test('calls downloadThemeSettings with minimal flags', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      mockDownloadThemeSettings.mockResolvedValue()
+
+      // When
+      const pull = new Pull([], {} as any)
+      const mockParse = vi.fn().mockResolvedValue({
+        flags: {
+          development: undefined,
+          live: undefined,
+          theme: undefined,
+          nodelete: undefined
+        }
+      })
+      // @ts-ignore - accessing protected method for testing
+      pull.parse = mockParse
+
+      await pull.run()
+
+      // Then
+      expect(mockDownloadThemeSettings).toHaveBeenCalledWith({
+        development: undefined,
+        live: undefined,
+        theme: undefined,
+        nodelete: undefined
+      })
+    })
+
+    test('propagates errors from downloadThemeSettings', async () => {
+      // Given
+      const mockDownloadThemeSettings = vi.mocked(themeUtils.downloadThemeSettings)
+      const testError = new Error('Download failed')
+      mockDownloadThemeSettings.mockRejectedValue(testError)
+
+      // When/Then
+      const pull = new Pull([], {} as any)
+      const mockParse = vi.fn().mockResolvedValue({
+        flags: {}
+      })
+      // @ts-ignore - accessing protected method for testing
+      pull.parse = mockParse
+
+      await expect(pull.run()).rejects.toThrow('Download failed')
+      expect(mockDownloadThemeSettings).toHaveBeenCalled()
+    })
+  })
+
+  describe('flag descriptions use pull terminology', () => {
+    test('development flag description mentions pull', () => {
+      expect(Pull.flags.development.description).toContain('Pull settings files from your remote development theme')
+    })
+
+    test('live flag description mentions pull', () => {
+      expect(Pull.flags.live.description).toContain('Pull settings files from your remote live theme')
+    })
+
+    test('nodelete flag description mentions pull command', () => {
+      expect(Pull.flags.nodelete.description).toContain('Runs the pull command without deleting local files')
+    })
+
+    test('theme flag description is neutral', () => {
+      expect(Pull.flags.theme.description).toBe('Theme ID or name of the remote theme.')
+    })
+  })
+
+  describe('inheritance verification', () => {
+    test('extends BaseCommand', () => {
+      const pull = new Pull([], {} as any)
+      expect(pull.constructor.name).toBe('Pull')
+    })
+
+    test('has run method', () => {
+      expect(typeof Pull.prototype.run).toBe('function')
+    })
+  })
+})

--- a/src/commands/theme/settings/pull.ts
+++ b/src/commands/theme/settings/pull.ts
@@ -1,0 +1,39 @@
+import { Flags } from '@oclif/core'
+import { globalFlags } from '@shopify/cli-kit/node/cli'
+import BaseCommand from '@shopify/cli-kit/node/base-command'
+import { themeFlags } from '../../../utilities/shopify/flags.js'
+import { downloadThemeSettings, DownloadFlags } from '../../../utilities/theme.js'
+
+export default class Pull extends BaseCommand {
+  static description = 'Pull settings from live theme.'
+
+  static flags = {
+    ...globalFlags,
+    ...themeFlags,
+    development: Flags.boolean({
+      char: 'd',
+      description: 'Pull settings files from your remote development theme.',
+      env: 'SHOPIFY_FLAG_DEVELOPMENT',
+    }),
+    live: Flags.boolean({
+      char: 'l',
+      description: 'Pull settings files from your remote live theme.',
+      env: 'SHOPIFY_FLAG_LIVE',
+    }),
+    theme: Flags.string({
+      char: 't',
+      description: 'Theme ID or name of the remote theme.',
+      env: 'SHOPIFY_FLAG_THEME_ID',
+    }),
+    nodelete: Flags.boolean({
+      char: 'n',
+      description: 'Runs the pull command without deleting local files.',
+      env: 'SHOPIFY_FLAG_NODELETE',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Pull)
+    await downloadThemeSettings(flags as DownloadFlags)
+  }
+}


### PR DESCRIPTION
In this PR, I alias `theme settings download` to `theme settings pull`. This change in command name aligns with Shopify's terminology for pushing and pulling data.

The use of `theme settings download` is now deprecated.
