### PR TITLE
feat(theme): mirror theme-scoped translations on blue/green deploy

### DIFF
--- a/docs/commands/readme.md
+++ b/docs/commands/readme.md
@@ -8,11 +8,12 @@
 * [`shopkeeper bucket restore`](#shopkeeper-bucket-restore)
 * [`shopkeeper bucket save`](#shopkeeper-bucket-save)
 * [`shopkeeper bucket switch`](#shopkeeper-bucket-switch)
-* [`shopkeeper help [COMMANDS]`](#shopkeeper-help-commands)
+* [`shopkeeper help [COMMAND]`](#shopkeeper-help-command)
 * [`shopkeeper theme create`](#shopkeeper-theme-create)
 * [`shopkeeper theme deploy`](#shopkeeper-theme-deploy)
 * [`shopkeeper theme get`](#shopkeeper-theme-get)
 * [`shopkeeper theme settings pull`](#shopkeeper-theme-settings-pull)
+* [`shopkeeper theme translations mirror`](#shopkeeper-theme-translations-mirror)
 
 ## `shopkeeper bucket create`
 
@@ -20,12 +21,12 @@ Create a bucket in .shopkeeper
 
 ```
 USAGE
-  $ shopkeeper bucket create -b <value> [--no-color] [--verbose]
+  $ shopkeeper bucket create -b <value>... [--no-color] [--verbose]
 
 FLAGS
-  -b, --bucket=<value>...  (required)
-      --no-color           Disable color output.
-      --verbose            Increase the verbosity of the output.
+  -b, --bucket=<value>...  (required) [env: SKR_FLAG_BUCKET]
+      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Create a bucket in .shopkeeper
@@ -42,8 +43,8 @@ USAGE
   $ shopkeeper bucket current [--no-color] [--verbose]
 
 FLAGS
-  --no-color  Disable color output.
-  --verbose   Increase the verbosity of the output.
+  --no-color  [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+  --verbose   [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Output the current bucket
@@ -57,13 +58,13 @@ Delete a bucket
 
 ```
 USAGE
-  $ shopkeeper bucket delete -b <value> [--no-color] [--verbose] [-f]
+  $ shopkeeper bucket delete -b <value>... [--no-color] [--verbose] [-f]
 
 FLAGS
-  -b, --bucket=<value>...  (required)
-  -f, --force              Skip confirmation.
-      --no-color           Disable color output.
-      --verbose            Increase the verbosity of the output.
+  -b, --bucket=<value>...  (required) [env: SKR_FLAG_BUCKET]
+  -f, --force              [env: SHOPIFY_FLAG_FORCE] Skip confirmation.
+      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Delete a bucket
@@ -77,12 +78,12 @@ Initialize .shopkeeper directory in the current directory
 
 ```
 USAGE
-  $ shopkeeper bucket init [--no-color] [--verbose] [-b <value>]
+  $ shopkeeper bucket init [--no-color] [--verbose] [-b <value>...]
 
 FLAGS
-  -b, --bucket=<value>...
-      --no-color           Disable color output.
-      --verbose            Increase the verbosity of the output.
+  -b, --bucket=<value>...  [env: SKR_FLAG_BUCKET]
+      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Initialize .shopkeeper directory in the current directory
@@ -99,8 +100,8 @@ USAGE
   $ shopkeeper bucket list [--no-color] [--verbose]
 
 FLAGS
-  --no-color  Disable color output.
-  --verbose   Increase the verbosity of the output.
+  --no-color  [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+  --verbose   [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   List buckets
@@ -117,12 +118,13 @@ USAGE
   $ shopkeeper bucket restore [--no-color] [--verbose] [--path <value>] [-e <value>] [--bucket <value>] [-n]
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -n, --nodelete             Runs the restore command without removing the theme's JSON settings.
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -n, --nodelete             [env: SHOPIFY_FLAG_NODELETE] Runs the restore command without removing the theme's JSON
+                             settings.
       --bucket=<value>       The bucket you want to restore your settings from.
-      --no-color             Disable color output.
-      --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the output.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>         [env: SHOPIFY_FLAG_PATH] The path to your theme directory.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Restores the theme settings from the specified bucket
@@ -139,12 +141,12 @@ USAGE
   $ shopkeeper bucket save [--no-color] [--verbose] [--path <value>] [-e <value>] [--bucket <value>] [-n]
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -n, --nodelete             Runs the save command without deleting the bucket's contents.
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -n, --nodelete             [env: SHOPIFY_FLAG_NODELETE] Runs the save command without deleting the bucket's contents.
       --bucket=<value>       The bucket where you want to save your settings.
-      --no-color             Disable color output.
-      --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the output.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>         [env: SHOPIFY_FLAG_PATH] The path to your theme directory.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Saves the current theme settings to the specified bucket
@@ -161,12 +163,13 @@ USAGE
   $ shopkeeper bucket switch [--no-color] [--verbose] [--path <value>] [-e <value>] [--bucket <value>] [-n]
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -n, --nodelete             Runs the restore command without removing the theme's JSON settings.
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -n, --nodelete             [env: SHOPIFY_FLAG_NODELETE] Runs the restore command without removing the theme's JSON
+                             settings.
       --bucket=<value>       The bucket to switch to
-      --no-color             Disable color output.
-      --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the output.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>         [env: SHOPIFY_FLAG_PATH] The path to your theme directory.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Switches the current bucket by copying settings and .env
@@ -174,16 +177,16 @@ DESCRIPTION
 
 _See code: [src/commands/bucket/switch.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/src/commands/bucket/switch.ts)_
 
-## `shopkeeper help [COMMANDS]`
+## `shopkeeper help [COMMAND]`
 
 Display help for shopkeeper.
 
 ```
 USAGE
-  $ shopkeeper help [COMMANDS...] [-n]
+  $ shopkeeper help [COMMAND...] [-n]
 
 ARGUMENTS
-  COMMANDS...  Command to show help for.
+  [COMMAND...]  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.
@@ -192,7 +195,7 @@ DESCRIPTION
   Display help for shopkeeper.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.0.1/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.41/src/commands/help.ts)_
 
 ## `shopkeeper theme create`
 
@@ -204,16 +207,16 @@ USAGE
     [-e <value>] [-n] [-j]
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -j, --json                 Output JSON instead of a UI.
-  -n, --nodelete             Runs the push command without deleting local files.
-  -s, --store=<value>        Store URL. It can be the store prefix (example) or the full myshopify.com URL
-                             (example.myshopify.com, https://example.myshopify.com).
-  -t, --theme=<value>        (required) Theme ID or name of the remote theme.
-      --no-color             Disable color output.
-      --password=<value>     Password generated from the Theme Access app.
-      --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the output.
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -j, --json                 [env: SHOPIFY_FLAG_JSON] Output JSON instead of a UI.
+  -n, --nodelete             [env: SHOPIFY_FLAG_NODELETE] Runs the push command without deleting local files.
+  -s, --store=<value>        [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
+                             myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+  -t, --theme=<value>        (required) [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --password=<value>     [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app.
+      --path=<value>         [env: SHOPIFY_FLAG_PATH] The path to your theme directory.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Create a theme with a name or ID. Update theme if one with name already exists
@@ -240,22 +243,27 @@ Deploy theme source to store
 ```
 USAGE
   $ shopkeeper theme deploy [--no-color] [--verbose] [--path <value>] [--password <value>] [-s <value>] [-e
-    <value>] [-n] [--publish] [--green <value>] [--blue <value>] [--strategy blue-green|basic]
+    <value>] [-n] [--publish] [--green <value>] [--blue <value>] [--strategy blue-green|basic] [--mirror-translations]
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -n, --nodelete             Runs the push command without deleting local files.
-  -s, --store=<value>        Store URL. It can be the store prefix (example) or the full myshopify.com URL
-                             (example.myshopify.com, https://example.myshopify.com).
-      --blue=<value>         Blue theme ID
-      --green=<value>        Green theme ID
-      --no-color             Disable color output.
-      --password=<value>     Password generated from the Theme Access app.
-      --path=<value>         The path to your theme directory.
-      --publish              Publishes the on-deck theme after deploying
-      --strategy=<option>    [default: blue-green] Strategy to use for deployment
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -n, --nodelete             [env: SHOPIFY_FLAG_NODELETE] Runs the push command without deleting local files.
+  -s, --store=<value>        [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
+                             myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+      --blue=<value>         [env: SKR_FLAG_BLUE_THEME_ID] Blue theme ID
+      --green=<value>        [env: SKR_FLAG_GREEN_THEME_ID] Green theme ID
+      --mirror-translations  [env: SKR_FLAG_MIRROR_TRANSLATIONS] Opt-in. Before deploying code, mirror theme-scoped
+                             translations (Translate & Adapt template / locale-content / settings translations) from the
+                             currently-live theme onto the on-deck theme. Default off; most stores do not register
+                             theme-scoped translations, and the pre-flight cost is not justified for them. Stores that
+                             use Translate & Adapt should enable this via SKR_FLAG_MIRROR_TRANSLATIONS=true.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --password=<value>     [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app.
+      --path=<value>         [env: SHOPIFY_FLAG_PATH] The path to your theme directory.
+      --publish              [env: SKR_FLAG_PUBLISH] Publishes the on-deck theme after deploying
+      --strategy=<option>    [default: blue-green, env: SKR_FLAG_STRATEGY] Strategy to use for deployment
                              <options: blue-green|basic>
-      --verbose              Increase the verbosity of the output.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Deploy theme source to store
@@ -272,14 +280,14 @@ USAGE
   $ shopkeeper theme get -t <value> [--no-color] [--verbose] [-s <value>] [--password <value>] [-e <value>] [-j]
 
 FLAGS
-  -e, --environment=<value>  The environment to apply to the current command.
-  -j, --json                 Output JSON instead of a UI.
-  -s, --store=<value>        Store URL. It can be the store prefix (example) or the full myshopify.com URL
-                             (example.myshopify.com, https://example.myshopify.com).
-  -t, --theme=<value>        (required) Theme ID or name of the remote theme.
-      --no-color             Disable color output.
-      --password=<value>     Password generated from the Theme Access app.
-      --verbose              Increase the verbosity of the output.
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -j, --json                 [env: SHOPIFY_FLAG_JSON] Output JSON instead of a UI.
+  -s, --store=<value>        [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
+                             myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+  -t, --theme=<value>        (required) [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --password=<value>     [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Get details of theme
@@ -297,21 +305,76 @@ USAGE
     <value>] [-d] [-l] [-t <value>] [-n]
 
 FLAGS
-  -d, --development          Pull settings files from your remote development theme.
-  -e, --environment=<value>  The environment to apply to the current command.
-  -l, --live                 Pull settings files from your remote live theme.
-  -n, --nodelete             Runs the pull command without deleting local files.
-  -s, --store=<value>        Store URL. It can be the store prefix (example) or the full myshopify.com URL
-                             (example.myshopify.com, https://example.myshopify.com).
-  -t, --theme=<value>        Theme ID or name of the remote theme.
-      --no-color             Disable color output.
-      --password=<value>     Password generated from the Theme Access app.
-      --path=<value>         The path to your theme directory.
-      --verbose              Increase the verbosity of the output.
+  -d, --development          [env: SHOPIFY_FLAG_DEVELOPMENT] Pull settings files from your remote development theme.
+  -e, --environment=<value>  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -l, --live                 [env: SHOPIFY_FLAG_LIVE] Pull settings files from your remote live theme.
+  -n, --nodelete             [env: SHOPIFY_FLAG_NODELETE] Runs the pull command without deleting local files.
+  -s, --store=<value>        [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
+                             myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+  -t, --theme=<value>        [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --no-color             [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --password=<value>     [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app.
+      --path=<value>         [env: SHOPIFY_FLAG_PATH] The path to your theme directory.
+      --verbose              [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Pull settings from live theme.
 ```
 
 _See code: [src/commands/theme/settings/pull.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/src/commands/theme/settings/pull.ts)_
+
+## `shopkeeper theme translations mirror`
+
+Mirror theme-scoped translations from one theme to another. Translations registered via the Translate & Adapt app (or any caller of translationsRegister) are keyed to a specific theme GID and do NOT migrate between themes — so a blue/green deploy strands them on the previously-live color unless something explicitly carries them across. This command does that.
+
+```
+USAGE
+  $ shopkeeper theme translations mirror [--no-color] [--verbose] [-s <value>] [--password <value>] [-e <value>] [--from
+    <value>] [--to <value>] [--blue <value>] [--green <value>] [--locale <value>] [--resource-type <value>] [--dry-run]
+
+FLAGS
+  -e, --environment=<value>    [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
+  -s, --store=<value>          [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
+                               myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+      --blue=<value>           [env: SKR_FLAG_BLUE_THEME_ID] Blue theme ID. Used when --from/--to are not provided: live
+                               theme becomes source, on-deck becomes target.
+      --dry-run                [env: SKR_FLAG_DRY_RUN] Build the write plan and print a summary, but do not invoke
+                               translationsRegister.
+      --from=<value>           [env: SKR_FLAG_FROM_THEME_ID] Source theme ID. When provided, must be combined with --to.
+                               Use this to anchor the mirror direction explicitly (e.g. for recovery scenarios where the
+                               most-up-to-date translation source is no longer [live]).
+      --green=<value>          [env: SKR_FLAG_GREEN_THEME_ID] Green theme ID. Pairs with --blue.
+      --locale=<value>         [env: SKR_FLAG_LOCALE] Mirror only this locale (e.g. "fr"). Defaults to every published
+                               non-primary locale on the store.
+      --no-color               [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --password=<value>       [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app.
+      --resource-type=<value>  [env: SKR_FLAG_RESOURCE_TYPE] Restrict the mirror to a single theme-scoped resource type.
+                               Useful for targeted ops or testing. Allowed: ONLINE_STORE_THEME,
+                               ONLINE_STORE_THEME_APP_EMBED, ONLINE_STORE_THEME_JSON_TEMPLATE,
+                               ONLINE_STORE_THEME_LOCALE_CONTENT, ONLINE_STORE_THEME_SECTION_GROUP,
+                               ONLINE_STORE_THEME_SETTINGS_CATEGORY, ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS.
+      --to=<value>             [env: SKR_FLAG_TO_THEME_ID] Target theme ID. When provided, must be combined with --from.
+      --verbose                [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+
+DESCRIPTION
+  Mirror theme-scoped translations from one theme to another. Translations registered via the Translate & Adapt app (or
+  any caller of translationsRegister) are keyed to a specific theme GID and do NOT migrate between themes — so a
+  blue/green deploy strands them on the previously-live color unless something explicitly carries them across. This
+  command does that.
+
+EXAMPLES
+  Mirror live -> on-deck before a blue/green deploy (standard use):
+
+    $ shopkeeper theme translations mirror --blue 134599540817 --green 134599737425
+
+  Recover translations stranded on a no-longer-live theme:
+
+    $ shopkeeper theme translations mirror --from 134599540817 --to 134599737425
+
+  Dry-run (print plan without writing):
+
+    $ shopkeeper theme translations mirror --blue 1 --green 2 --dry-run
+```
+
+_See code: [src/commands/theme/translations/mirror.ts](https://github.com/TheBeyondGroup/shopkeeper/tree/main/src/src/commands/theme/translations/mirror.ts)_
 <!-- commandsstop -->

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,315 +1,5 @@
 {
   "commands": {
-    "theme:create": {
-      "aliases": [],
-      "args": {},
-      "description": "Create a theme with theme name or ID.\nIn most cases, you should use theme push.\n\nThis command exists for the case when you want create a theme by name that may\nor may not exist. It will ensure that if one with the same name already exists,\nit is updated.\n\ntheme push --unpublished --theme yellow will create a new theme named yellow each\ntime the command is run.\n\nAs a result this command exists.\n",
-      "flags": {
-        "no-color": {
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your theme directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "name": "path",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "name": "password",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "name": "store",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "name": "environment",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "name": "theme",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "nodelete": {
-          "char": "n",
-          "description": "Runs the push command without deleting local files.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "char": "j",
-          "description": "Output JSON instead of a UI.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "theme:create",
-      "pluginAlias": "@thebeyondgroup/shopkeeper",
-      "pluginName": "@thebeyondgroup/shopkeeper",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Create a theme with a name or ID. Update theme if one with name already exists",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "theme",
-        "create.js"
-      ]
-    },
-    "theme:deploy": {
-      "aliases": [],
-      "args": {},
-      "description": "Deploy theme source to store",
-      "flags": {
-        "no-color": {
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your theme directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "name": "path",
-          "noCacheDefault": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "name": "password",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "name": "store",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "name": "environment",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "nodelete": {
-          "char": "n",
-          "description": "Runs the push command without deleting local files.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "publish": {
-          "description": "Publishes the on-deck theme after deploying",
-          "env": "SKR_FLAG_PUBLISH",
-          "name": "publish",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "green": {
-          "description": "Green theme ID",
-          "env": "SKR_FLAG_GREEN_THEME_ID",
-          "name": "green",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "blue": {
-          "description": "Blue theme ID",
-          "env": "SKR_FLAG_BLUE_THEME_ID",
-          "name": "blue",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "strategy": {
-          "description": "Strategy to use for deployment",
-          "env": "SKR_FLAG_STRATEGY",
-          "name": "strategy",
-          "relationships": [
-            {
-              "type": "all",
-              "flags": [
-                {
-                  "name": "blue"
-                },
-                {
-                  "name": "green"
-                }
-              ]
-            }
-          ],
-          "default": "blue-green",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "blue-green",
-            "basic"
-          ],
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "theme:deploy",
-      "pluginAlias": "@thebeyondgroup/shopkeeper",
-      "pluginName": "@thebeyondgroup/shopkeeper",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "theme",
-        "deploy.js"
-      ]
-    },
-    "theme:get": {
-      "aliases": [],
-      "args": {},
-      "description": "Get details of theme",
-      "flags": {
-        "no-color": {
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "name": "store",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "name": "password",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "name": "environment",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "name": "theme",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "json": {
-          "char": "j",
-          "description": "Output JSON instead of a UI.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "theme:get",
-      "pluginAlias": "@thebeyondgroup/shopkeeper",
-      "pluginName": "@thebeyondgroup/shopkeeper",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "theme",
-        "get.js"
-      ]
-    },
     "bucket:create": {
       "aliases": [],
       "args": {},
@@ -747,6 +437,323 @@
         "switch.js"
       ]
     },
+    "theme:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create a theme with theme name or ID.\nIn most cases, you should use theme push.\n\nThis command exists for the case when you want create a theme by name that may\nor may not exist. It will ensure that if one with the same name already exists,\nit is updated.\n\ntheme push --unpublished --theme yellow will create a new theme named yellow each\ntime the command is run.\n\nAs a result this command exists.\n",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your theme directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Runs the push command without deleting local files.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output JSON instead of a UI.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:create",
+      "pluginAlias": "@thebeyondgroup/shopkeeper",
+      "pluginName": "@thebeyondgroup/shopkeeper",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Create a theme with a name or ID. Update theme if one with name already exists",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "theme",
+        "create.js"
+      ]
+    },
+    "theme:deploy": {
+      "aliases": [],
+      "args": {},
+      "description": "Deploy theme source to store",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your theme directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Runs the push command without deleting local files.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "publish": {
+          "description": "Publishes the on-deck theme after deploying",
+          "env": "SKR_FLAG_PUBLISH",
+          "name": "publish",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "green": {
+          "description": "Green theme ID",
+          "env": "SKR_FLAG_GREEN_THEME_ID",
+          "name": "green",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "blue": {
+          "description": "Blue theme ID",
+          "env": "SKR_FLAG_BLUE_THEME_ID",
+          "name": "blue",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "strategy": {
+          "description": "Strategy to use for deployment",
+          "env": "SKR_FLAG_STRATEGY",
+          "name": "strategy",
+          "relationships": [
+            {
+              "type": "all",
+              "flags": [
+                {
+                  "name": "blue"
+                },
+                {
+                  "name": "green"
+                }
+              ]
+            }
+          ],
+          "default": "blue-green",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "blue-green",
+            "basic"
+          ],
+          "type": "option"
+        },
+        "mirror-translations": {
+          "description": "Opt-in. Before deploying code, mirror theme-scoped translations (Translate & Adapt template / locale-content / settings translations) from the currently-live theme onto the on-deck theme. Default off; most stores do not register theme-scoped translations, and the pre-flight cost is not justified for them. Stores that use Translate & Adapt should enable this via SKR_FLAG_MIRROR_TRANSLATIONS=true.",
+          "env": "SKR_FLAG_MIRROR_TRANSLATIONS",
+          "name": "mirror-translations",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:deploy",
+      "pluginAlias": "@thebeyondgroup/shopkeeper",
+      "pluginName": "@thebeyondgroup/shopkeeper",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "theme",
+        "deploy.js"
+      ]
+    },
+    "theme:get": {
+      "aliases": [],
+      "args": {},
+      "description": "Get details of theme",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output JSON instead of a UI.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:get",
+      "pluginAlias": "@thebeyondgroup/shopkeeper",
+      "pluginName": "@thebeyondgroup/shopkeeper",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "theme",
+        "get.js"
+      ]
+    },
     "theme:settings:download": {
       "aliases": [],
       "args": {},
@@ -960,6 +967,140 @@
         "theme",
         "settings",
         "pull.js"
+      ]
+    },
+    "theme:translations:mirror": {
+      "aliases": [],
+      "args": {},
+      "description": "Mirror theme-scoped translations from one theme to another. Translations registered via the Translate & Adapt app (or any caller of translationsRegister) are keyed to a specific theme GID and do NOT migrate between themes — so a blue/green deploy strands them on the previously-live color unless something explicitly carries them across. This command does that.",
+      "examples": [
+        {
+          "description": "Mirror live -> on-deck before a blue/green deploy (standard use):",
+          "command": "<%= config.bin %> <%= command.id %> --blue 134599540817 --green 134599737425"
+        },
+        {
+          "description": "Recover translations stranded on a no-longer-live theme:",
+          "command": "<%= config.bin %> <%= command.id %> --from 134599540817 --to 134599737425"
+        },
+        {
+          "description": "Dry-run (print plan without writing):",
+          "command": "<%= config.bin %> <%= command.id %> --blue 1 --green 2 --dry-run"
+        }
+      ],
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "from": {
+          "description": "Source theme ID. When provided, must be combined with --to. Use this to anchor the mirror direction explicitly (e.g. for recovery scenarios where the most-up-to-date translation source is no longer [live]).",
+          "env": "SKR_FLAG_FROM_THEME_ID",
+          "name": "from",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "to": {
+          "description": "Target theme ID. When provided, must be combined with --from.",
+          "env": "SKR_FLAG_TO_THEME_ID",
+          "name": "to",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "blue": {
+          "description": "Blue theme ID. Used when --from/--to are not provided: live theme becomes source, on-deck becomes target.",
+          "env": "SKR_FLAG_BLUE_THEME_ID",
+          "name": "blue",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "green": {
+          "description": "Green theme ID. Pairs with --blue.",
+          "env": "SKR_FLAG_GREEN_THEME_ID",
+          "name": "green",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "locale": {
+          "description": "Mirror only this locale (e.g. \"fr\"). Defaults to every published non-primary locale on the store.",
+          "env": "SKR_FLAG_LOCALE",
+          "name": "locale",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "resource-type": {
+          "description": "Restrict the mirror to a single theme-scoped resource type. Useful for targeted ops or testing. Allowed: ONLINE_STORE_THEME, ONLINE_STORE_THEME_APP_EMBED, ONLINE_STORE_THEME_JSON_TEMPLATE, ONLINE_STORE_THEME_LOCALE_CONTENT, ONLINE_STORE_THEME_SECTION_GROUP, ONLINE_STORE_THEME_SETTINGS_CATEGORY, ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS.",
+          "env": "SKR_FLAG_RESOURCE_TYPE",
+          "name": "resource-type",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dry-run": {
+          "description": "Build the write plan and print a summary, but do not invoke translationsRegister.",
+          "env": "SKR_FLAG_DRY_RUN",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:translations:mirror",
+      "pluginAlias": "@thebeyondgroup/shopkeeper",
+      "pluginName": "@thebeyondgroup/shopkeeper",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "theme",
+        "translations",
+        "mirror.js"
       ]
     }
   },

--- a/src/commands/theme/deploy.ts
+++ b/src/commands/theme/deploy.ts
@@ -44,6 +44,12 @@ export default class Deploy extends ThemeCommand {
         },
       ],
     }),
+    'mirror-translations': Flags.boolean({
+      description:
+        'Opt-in. Before deploying code, mirror theme-scoped translations (Translate & Adapt template / locale-content / settings translations) from the currently-live theme onto the on-deck theme. Default off; most stores do not register theme-scoped translations, and the pre-flight cost is not justified for them. Stores that use Translate & Adapt should enable this via SKR_FLAG_MIRROR_TRANSLATIONS=true.',
+      default: false,
+      env: 'SKR_FLAG_MIRROR_TRANSLATIONS',
+    }),
   }
 
   async run(): Promise<void> {
@@ -60,6 +66,7 @@ export default class Deploy extends ThemeCommand {
       strategy: flags.strategy,
       green: flags.green,
       blue: flags.blue,
+      mirrorTranslations: flags['mirror-translations'],
     }
     await deploy(deployFlags)
   }

--- a/src/commands/theme/translations/mirror.ts
+++ b/src/commands/theme/translations/mirror.ts
@@ -1,0 +1,82 @@
+import {Flags} from '@oclif/core'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import BaseCommand from '@shopify/cli-kit/node/base-command'
+import {themeFlags} from '../../../utilities/shopify/flags.js'
+import {mirrorTranslations, MirrorTranslationsFlags} from '../../../services/theme/translations.js'
+
+export default class Mirror extends BaseCommand {
+  static description =
+    'Mirror theme-scoped translations from one theme to another. Translations registered via the Translate & Adapt app (or any caller of translationsRegister) are keyed to a specific theme GID and do NOT migrate between themes — so a blue/green deploy strands them on the previously-live color unless something explicitly carries them across. This command does that.'
+
+  static examples = [
+    {
+      description: 'Mirror live -> on-deck before a blue/green deploy (standard use):',
+      command: '<%= config.bin %> <%= command.id %> --blue 134599540817 --green 134599737425',
+    },
+    {
+      description: 'Recover translations stranded on a no-longer-live theme:',
+      command: '<%= config.bin %> <%= command.id %> --from 134599540817 --to 134599737425',
+    },
+    {
+      description: 'Dry-run (print plan without writing):',
+      command: '<%= config.bin %> <%= command.id %> --blue 1 --green 2 --dry-run',
+    },
+  ]
+
+  static flags = {
+    ...globalFlags,
+    store: themeFlags.store,
+    password: themeFlags.password,
+    environment: themeFlags.environment,
+    from: Flags.integer({
+      description:
+        'Source theme ID. When provided, must be combined with --to. Use this to anchor the mirror direction explicitly (e.g. for recovery scenarios where the most-up-to-date translation source is no longer [live]).',
+      env: 'SKR_FLAG_FROM_THEME_ID',
+    }),
+    to: Flags.integer({
+      description: 'Target theme ID. When provided, must be combined with --from.',
+      env: 'SKR_FLAG_TO_THEME_ID',
+    }),
+    blue: Flags.integer({
+      description:
+        'Blue theme ID. Used when --from/--to are not provided: live theme becomes source, on-deck becomes target.',
+      env: 'SKR_FLAG_BLUE_THEME_ID',
+    }),
+    green: Flags.integer({
+      description: 'Green theme ID. Pairs with --blue.',
+      env: 'SKR_FLAG_GREEN_THEME_ID',
+    }),
+    locale: Flags.string({
+      description: 'Mirror only this locale (e.g. "fr"). Defaults to every published non-primary locale on the store.',
+      env: 'SKR_FLAG_LOCALE',
+    }),
+    'resource-type': Flags.string({
+      description:
+        'Restrict the mirror to a single theme-scoped resource type. Useful for targeted ops or testing. Allowed: ONLINE_STORE_THEME, ONLINE_STORE_THEME_APP_EMBED, ONLINE_STORE_THEME_JSON_TEMPLATE, ONLINE_STORE_THEME_LOCALE_CONTENT, ONLINE_STORE_THEME_SECTION_GROUP, ONLINE_STORE_THEME_SETTINGS_CATEGORY, ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS.',
+      env: 'SKR_FLAG_RESOURCE_TYPE',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Build the write plan and print a summary, but do not invoke translationsRegister.',
+      env: 'SKR_FLAG_DRY_RUN',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(Mirror)
+    const serviceFlags: MirrorTranslationsFlags = {
+      store: flags.store,
+      password: flags.password,
+      from: flags.from,
+      to: flags.to,
+      blue: flags.blue,
+      green: flags.green,
+      locale: flags.locale,
+      resourceType: flags['resource-type'],
+      dryRun: flags['dry-run'],
+      noColor: flags['no-color'],
+      verbose: flags.verbose,
+    }
+    await mirrorTranslations(serviceFlags)
+  }
+}

--- a/src/services/theme/deploy.test.ts
+++ b/src/services/theme/deploy.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {
   basicDeploy,
   blueGreenDeploy,
@@ -8,16 +8,17 @@ import {
   getOnDeckThemeId,
   gitHeadHash,
 } from './deploy.js'
-import { findPathUp } from '@shopify/cli-kit/node/fs'
-import { getLatestGitCommit } from '@shopify/cli-kit/node/git'
-import { BLUE_GREEN_STRATEGY } from '../../utilities/constants.js'
-import { Theme } from '@shopify/cli-kit/node/themes/types'
-import { outputInfo } from '@shopify/cli-kit/node/output'
-import { themeUpdate } from '@shopify/cli-kit/node/themes/api'
-import { deployToLive, deployTheme, pullLiveThemeSettings } from '../../utilities/theme.js'
-import { findThemes } from '../../utilities/shopify/theme-selector.js'
-import { ensureAuthenticatedThemes } from '@shopify/cli-kit/node/session'
-import { getThemeStore } from '../../utilities/shopify/services/local-storage.js'
+import {findPathUp} from '@shopify/cli-kit/node/fs'
+import {getLatestGitCommit} from '@shopify/cli-kit/node/git'
+import {BLUE_GREEN_STRATEGY} from '../../utilities/constants.js'
+import {Theme} from '@shopify/cli-kit/node/themes/types'
+import {outputInfo} from '@shopify/cli-kit/node/output'
+import {themeUpdate} from '@shopify/cli-kit/node/themes/api'
+import {deployToLive, deployTheme, pullLiveThemeSettings} from '../../utilities/theme.js'
+import {findThemes} from '../../utilities/shopify/theme-selector.js'
+import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {getThemeStore} from '../../utilities/shopify/services/local-storage.js'
+import {mirrorTranslations} from './translations.js'
 
 vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/git')
@@ -27,13 +28,14 @@ vi.mock('@shopify/cli-kit/node/session')
 vi.mock('../../utilities/shopify/theme-selector.js')
 vi.mock('../../utilities/theme.js')
 vi.mock('../../utilities/shopify/services/local-storage.js')
+vi.mock('./translations.js')
 
 describe('deploy', () => {
-  const adminSession = { token: 'ABC', storeFqdn: 'example.myshopify.com' }
+  const adminSession = {token: 'ABC', storeFqdn: 'example.myshopify.com'}
   const path = '/my-theme'
 
   function theme(id: number, role: string) {
-    return { id, role, name: `theme (${id})` } as Theme
+    return {id, role, name: `theme (${id})`} as Theme
   }
 
   beforeEach(async () => {
@@ -42,7 +44,7 @@ describe('deploy', () => {
 
   describe('deploy', () => {
     describe('when blue/green strategy', () => {
-      test('makes blue/green deploy', async () => {
+      test('makes blue/green deploy without mirroring translations by default', async () => {
         // Given
         const green = 1
         const blue = 2
@@ -74,11 +76,89 @@ describe('deploy', () => {
         await deploy(flags)
 
         // Then
-        expect(outputInfo).toHaveBeenCalledTimes(2)
         expect(outputInfo).toHaveBeenCalledWith('Pulling theme settings')
         expect(pullLiveThemeSettings).toBeCalledWith(flags)
+        expect(mirrorTranslations).not.toHaveBeenCalled()
         expect(deployTheme).toBeCalledWith(green, flags)
         expect(outputInfo).toHaveBeenCalledWith('Green renamed to [BABCD123] Production - Green')
+      })
+
+      test('mirrors translations when mirrorTranslations is set', async () => {
+        // Given
+        const green = 1
+        const blue = 2
+        const liveTheme = theme(blue, 'main')
+        const themes = [theme(green, 'unpublished'), liveTheme]
+        vi.mocked(getThemeStore).mockReturnValue('')
+        vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(adminSession)
+        vi.mocked(findThemes).mockResolvedValue([liveTheme])
+        vi.mocked(themeUpdate).mockResolvedValue(themes[1])
+        vi.mocked(findPathUp).mockResolvedValue('path')
+        vi.mocked(getLatestGitCommit).mockResolvedValue({
+          hash: 'BABCD1234AB',
+          date: '',
+          message: '',
+          refs: '',
+          body: '',
+          author_name: '',
+          author_email: '',
+        })
+        const flags: DeployFlags = {
+          store: 'test',
+          green: green,
+          blue: blue,
+          strategy: BLUE_GREEN_STRATEGY,
+          publish: false,
+          mirrorTranslations: true,
+        }
+
+        // When
+        await deploy(flags)
+
+        // Then
+        expect(mirrorTranslations).toBeCalledWith({
+          store: 'test',
+          password: undefined,
+          from: blue,
+          to: green,
+        })
+        expect(deployTheme).toBeCalledWith(green, flags)
+      })
+
+      test('continues deploy when translation mirror throws', async () => {
+        // Given
+        const green = 1
+        const blue = 2
+        const liveTheme = theme(blue, 'main')
+        vi.mocked(getThemeStore).mockReturnValue('')
+        vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(adminSession)
+        vi.mocked(findThemes).mockResolvedValue([liveTheme])
+        vi.mocked(themeUpdate).mockResolvedValue(theme(green, 'unpublished'))
+        vi.mocked(findPathUp).mockResolvedValue('path')
+        vi.mocked(getLatestGitCommit).mockResolvedValue({
+          hash: 'BABCD1234AB',
+          date: '',
+          message: '',
+          refs: '',
+          body: '',
+          author_name: '',
+          author_email: '',
+        })
+        vi.mocked(mirrorTranslations).mockRejectedValue(new Error('admin API down'))
+        const flags: DeployFlags = {
+          store: 'test',
+          green: green,
+          blue: blue,
+          strategy: BLUE_GREEN_STRATEGY,
+          publish: false,
+          mirrorTranslations: true,
+        }
+
+        // When
+        await deploy(flags)
+
+        // Then — the code deploy should still happen even if translation mirror failed
+        expect(deployTheme).toBeCalledWith(green, flags)
       })
     })
 
@@ -144,15 +224,23 @@ describe('deploy', () => {
         blue: blue,
         strategy: BLUE_GREEN_STRATEGY,
         publish: false,
+        mirrorTranslations: true,
       }
 
       // When
       await blueGreenDeploy(flags)
 
       // Then
-      expect(outputInfo).toHaveBeenCalledTimes(2)
+      expect(outputInfo).toHaveBeenCalledTimes(3)
       expect(outputInfo).toHaveBeenCalledWith('Pulling theme settings')
+      expect(outputInfo).toHaveBeenCalledWith('Mirroring theme-scoped translations from live to on-deck')
       expect(pullLiveThemeSettings).toBeCalledWith(flags)
+      expect(mirrorTranslations).toBeCalledWith({
+        store: undefined,
+        password: undefined,
+        from: blue,
+        to: green,
+      })
       expect(deployTheme).toBeCalledWith(green, flags)
       expect(outputInfo).toHaveBeenCalledWith('Green renamed to [BABCD123] Production - Green')
     })
@@ -220,7 +308,9 @@ describe('deploy', () => {
         }
 
         // Then
-        await expect(errorFunc).rejects.toThrowError(/Something very bad has happened. The store doesn't have a live theme./)
+        await expect(errorFunc).rejects.toThrowError(
+          /Something very bad has happened. The store doesn't have a live theme./,
+        )
       })
     })
   })

--- a/src/services/theme/deploy.ts
+++ b/src/services/theme/deploy.ts
@@ -5,9 +5,10 @@ import {getLatestGitCommit} from '@shopify/cli-kit/node/git'
 import {deployToLive, deployTheme as deployTheme, pullLiveThemeSettings} from '../../utilities/theme.js'
 import {findPathUp} from '@shopify/cli-kit/node/fs'
 import {BLUE_GREEN_STRATEGY} from '../../utilities/constants.js'
-import {outputInfo} from '@shopify/cli-kit/node/output'
+import {outputInfo, outputWarn} from '@shopify/cli-kit/node/output'
 import {findThemes} from '../../utilities/shopify/theme-selector.js'
 import {ensureThemeStore} from '../../utilities/shopify/theme-store.js'
+import {mirrorTranslations as runMirrorTranslations} from './translations.js'
 
 type OnDeckTheme = {
   id: number
@@ -48,6 +49,21 @@ export interface DeployFlags {
   strategy: string
   blue?: number
   green?: number
+
+  /**
+   * Opt-in. When true, mirror theme-scoped translations (Translate & Adapt
+   * template / locale-content / settings translations) from the currently-
+   * live theme onto the on-deck theme before deploying code. Translations
+   * registered via the Translations API are keyed to a theme GID, so without
+   * this step they are stranded on the previously-live color and disappear
+   * from the storefront on promotion.
+   *
+   * Default-off because most client stores don't use Translate & Adapt and
+   * paying the (cheap, but non-zero) pre-flight cost on every deploy isn't
+   * justified for them. Stores that do use it (Hiya) should set
+   * SKR_FLAG_MIRROR_TRANSLATIONS=true in their deploy environment.
+   */
+  mirrorTranslations?: boolean
 }
 
 export async function deploy(flags: DeployFlags) {
@@ -72,6 +88,24 @@ export async function blueGreenDeploy(flags: DeployFlags) {
 
   const liveThemeId = await getLiveTheme(adminSession)
   const onDeckTheme = getOnDeckThemeId(liveThemeId, blue!, green!)
+
+  if (flags.mirrorTranslations) {
+    try {
+      outputInfo('Mirroring theme-scoped translations from live to on-deck')
+      await runMirrorTranslations({
+        store: flags.store,
+        password: flags.password,
+        from: liveThemeId,
+        to: onDeckTheme.id,
+      })
+    } catch (error) {
+      outputWarn(
+        `Failed to mirror theme translations before deploy. Theme-scoped translations registered via Translate & Adapt on the previously-live theme may not appear after this deploy promotes ${onDeckTheme.name}.`,
+      )
+      outputWarn(error instanceof Error ? error.message : String(error))
+    }
+  }
+
   await deployTheme(onDeckTheme.id, flags)
 
   const headSHA = await gitHeadHash()

--- a/src/services/theme/translations.test.ts
+++ b/src/services/theme/translations.test.ts
@@ -1,0 +1,317 @@
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {mirrorTranslations, resolveThemes} from './translations.js'
+import {ensureThemeStore} from '../../utilities/shopify/theme-store.js'
+import {getLiveTheme, getOnDeckThemeId} from './deploy.js'
+import {
+  fetchTranslatableResource,
+  listLiveThemeResourcesWithContent,
+  listThemeResources,
+  publishedNonPrimaryLocales,
+  registerTranslations,
+  TranslatableResource,
+} from '../../utilities/translations.js'
+
+vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/output')
+vi.mock('../../utilities/shopify/theme-store.js')
+vi.mock('../../utilities/translations.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utilities/translations.js')>(
+    '../../utilities/translations.js',
+  )
+  return {
+    ...actual,
+    fetchTranslatableResource: vi.fn(),
+    listLiveThemeResourcesWithContent: vi.fn(),
+    listThemeResources: vi.fn(),
+    publishedNonPrimaryLocales: vi.fn(),
+    registerTranslations: vi.fn(),
+  }
+})
+vi.mock('./deploy.js')
+
+const session: AdminSession = {token: 'TKN', storeFqdn: 'example.myshopify.com'}
+
+// Tests deliberately pass a --resource-type filter on the happy paths so the
+// isMirrorNeeded pre-flight is skipped (pre-flight is opinionated and tested
+// separately). The recovery path is exercised by passing from/to explicitly
+// (resolveThemes returns sourceIsLive=false), which uses listThemeResources +
+// per-resource fetch rather than listLiveThemeResourcesWithContent.
+
+const RECOVERY_FLAGS = {password: 'shptka_xxx', from: 1, to: 2} as const
+
+describe('resolveThemes', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  test('uses explicit --from/--to when provided', async () => {
+    vi.mocked(getLiveTheme).mockRejectedValue(new Error('no live theme'))
+    const result = await resolveThemes(session, {from: 100, to: 200})
+    expect(result).toEqual({fromThemeId: '100', toThemeId: '200', sourceIsLive: false})
+  })
+
+  test('sets sourceIsLive when explicit --from matches the live theme', async () => {
+    vi.mocked(getLiveTheme).mockResolvedValue(100)
+    const result = await resolveThemes(session, {from: 100, to: 200})
+    expect(result.sourceIsLive).toBe(true)
+  })
+
+  test('throws when only one of --from/--to is provided', async () => {
+    await expect(resolveThemes(session, {from: 100})).rejects.toThrow(AbortError)
+    await expect(resolveThemes(session, {to: 200})).rejects.toThrow(AbortError)
+  })
+
+  test('throws when neither --from/--to nor --blue/--green are provided', async () => {
+    await expect(resolveThemes(session, {})).rejects.toThrow(AbortError)
+  })
+
+  test('derives source = live, target = on-deck from blue/green', async () => {
+    vi.mocked(getLiveTheme).mockResolvedValue(2)
+    vi.mocked(getOnDeckThemeId).mockReturnValue({id: 1, name: 'Green'})
+    const result = await resolveThemes(session, {blue: 2, green: 1})
+    expect(result).toEqual({fromThemeId: '2', toThemeId: '1', sourceIsLive: true})
+    expect(getLiveTheme).toHaveBeenCalledWith(session)
+    expect(getOnDeckThemeId).toHaveBeenCalledWith(2, 2, 1)
+  })
+})
+
+function resource(themeId: number, contentKeys: string[], translations: Array<{key: string; value: string}>) {
+  return {
+    resourceId: `gid://shopify/OnlineStoreThemeJsonTemplate/product.foo?theme_id=${themeId}`,
+    translatableContent: contentKeys.map((k) => ({key: k, digest: `digest-${k}`, locale: 'en'})),
+    translations: translations.map((t) => ({...t, locale: 'fr'})),
+  } as TranslatableResource
+}
+
+describe('mirrorTranslations', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(ensureThemeStore).mockReturnValue('example.myshopify.com')
+    vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(session)
+    vi.mocked(getLiveTheme).mockRejectedValue(new Error('no live theme'))
+  })
+
+  test('requires a Theme Access password', async () => {
+    await expect(mirrorTranslations({from: 1, to: 2})).rejects.toThrow(AbortError)
+  })
+
+  test('refuses to mirror from a theme to itself', async () => {
+    await expect(mirrorTranslations({password: 'shptka_x', from: 5, to: 5})).rejects.toThrow(AbortError)
+  })
+
+  test('no-ops when there are no non-primary published locales', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue([])
+    const result = await mirrorTranslations(RECOVERY_FLAGS)
+    expect(result.locales).toEqual([])
+    expect(result.skipped).toBe(false)
+    expect(registerTranslations).not.toHaveBeenCalled()
+  })
+
+  test('writes translations whose source content digest exists on the target', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    vi.mocked(listThemeResources).mockResolvedValue([
+      {
+        resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+        resourceId: 'gid://shopify/OnlineStoreThemeJsonTemplate/product.foo?theme_id=1',
+      },
+    ])
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      if (rid.endsWith('theme_id=1')) {
+        return resource(
+          1,
+          ['headline', 'cta'],
+          [
+            {key: 'headline', value: 'Bonjour'},
+            {key: 'cta', value: 'Acheter'},
+          ],
+        )
+      }
+      return resource(2, ['headline'], [])
+    })
+    vi.mocked(registerTranslations).mockResolvedValue({written: 1, errors: []})
+
+    const result = await mirrorTranslations({
+      ...RECOVERY_FLAGS,
+      resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+    })
+
+    expect(registerTranslations).toHaveBeenCalledOnce()
+    expect(registerTranslations).toHaveBeenCalledWith(
+      session,
+      'gid://shopify/OnlineStoreThemeJsonTemplate/product.foo?theme_id=2',
+      [{key: 'headline', value: 'Bonjour', locale: 'fr', translatableContentDigest: 'digest-headline'}],
+    )
+    expect(result.perLocale[0]?.writes).toBe(1)
+    expect(result.perLocale[0]?.skippedKeysMissingOnTarget).toBe(1)
+  })
+
+  test('skips writes when target value already matches source (idempotent)', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    vi.mocked(listThemeResources).mockResolvedValue([
+      {
+        resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+        resourceId: 'gid://shopify/OnlineStoreThemeJsonTemplate/product.foo?theme_id=1',
+      },
+    ])
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      const themeId = rid.includes('theme_id=1') ? 1 : 2
+      return resource(themeId, ['headline'], [{key: 'headline', value: 'Bonjour'}])
+    })
+
+    const result = await mirrorTranslations({
+      ...RECOVERY_FLAGS,
+      resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+    })
+
+    expect(registerTranslations).not.toHaveBeenCalled()
+    expect(result.perLocale[0]?.alreadyInSync).toBe(1)
+    expect(result.perLocale[0]?.writes).toBe(0)
+  })
+
+  test('dryRun builds the plan but does not call registerTranslations', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    vi.mocked(listThemeResources).mockResolvedValue([
+      {
+        resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+        resourceId: 'gid://shopify/OnlineStoreThemeJsonTemplate/product.foo?theme_id=1',
+      },
+    ])
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      if (rid.includes('theme_id=1')) {
+        return resource(1, ['headline'], [{key: 'headline', value: 'Bonjour'}])
+      }
+      return resource(2, ['headline'], [])
+    })
+
+    const result = await mirrorTranslations({
+      ...RECOVERY_FLAGS,
+      resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+      dryRun: true,
+    })
+
+    expect(registerTranslations).not.toHaveBeenCalled()
+    expect(result.perLocale[0]?.writes).toBe(1)
+  })
+
+  test('skips resources that do not exist on the target theme', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    vi.mocked(listThemeResources).mockResolvedValue([
+      {
+        resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+        resourceId: 'gid://shopify/OnlineStoreThemeJsonTemplate/product.gone?theme_id=1',
+      },
+    ])
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      if (rid.includes('theme_id=1')) {
+        return resource(1, ['headline'], [{key: 'headline', value: 'Bonjour'}])
+      }
+      return null
+    })
+
+    const result = await mirrorTranslations({
+      ...RECOVERY_FLAGS,
+      resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+    })
+
+    expect(registerTranslations).not.toHaveBeenCalled()
+    expect(result.perLocale[0]?.skippedResourcesMissingOnTarget).toBe(1)
+  })
+
+  test('honors --locale to restrict to a single locale instead of every published non-primary', async () => {
+    vi.mocked(listThemeResources).mockResolvedValue([])
+
+    await mirrorTranslations({
+      ...RECOVERY_FLAGS,
+      resourceType: 'ONLINE_STORE_THEME_JSON_TEMPLATE',
+      locale: 'es',
+    })
+
+    expect(publishedNonPrimaryLocales).not.toHaveBeenCalled()
+  })
+
+  test('rejects unknown --resource-type values', async () => {
+    await expect(mirrorTranslations({...RECOVERY_FLAGS, resourceType: 'NOT_A_REAL_TYPE'})).rejects.toThrow(AbortError)
+  })
+
+  test('skips full mirror when pre-flight check finds source and target already in sync', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    // Pre-flight queries three resource types; return identical translations
+    // on both sides for each, which should short-circuit the mirror.
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      return {
+        resourceId: rid,
+        translatableContent: [{key: 'k1', digest: 'd1', locale: 'en'}],
+        translations: [{key: 'k1', value: 'Bonjour', locale: 'fr'}],
+      } as TranslatableResource
+    })
+
+    const result = await mirrorTranslations(RECOVERY_FLAGS)
+
+    expect(result.skipped).toBe(true)
+    expect(result.perLocale).toEqual([])
+    expect(listThemeResources).not.toHaveBeenCalled()
+    expect(listLiveThemeResourcesWithContent).not.toHaveBeenCalled()
+    expect(registerTranslations).not.toHaveBeenCalled()
+  })
+
+  test('proceeds with full mirror when pre-flight check finds differences', async () => {
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    let call = 0
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      call += 1
+      // Pre-flight: first pair (ONLINE_STORE_THEME source then target) differ.
+      if (call === 1) {
+        return {
+          resourceId: rid,
+          translatableContent: [{key: 'k1', digest: 'd1', locale: 'en'}],
+          translations: [{key: 'k1', value: 'Bonjour', locale: 'fr'}],
+        } as TranslatableResource
+      }
+      if (call === 2) {
+        return {
+          resourceId: rid,
+          translatableContent: [{key: 'k1', digest: 'd1', locale: 'en'}],
+          translations: [],
+        } as TranslatableResource
+      }
+      // After pre-flight: full mirror per-resource fetches.
+      return null
+    })
+    vi.mocked(listThemeResources).mockResolvedValue([])
+
+    const result = await mirrorTranslations(RECOVERY_FLAGS)
+
+    expect(result.skipped).toBe(false)
+    expect(listThemeResources).toHaveBeenCalledOnce()
+  })
+
+  test('uses listLiveThemeResourcesWithContent when source is live', async () => {
+    vi.mocked(getLiveTheme).mockResolvedValue(1)
+    vi.mocked(publishedNonPrimaryLocales).mockResolvedValue(['fr'])
+    // Pre-flight: differences forcing a full mirror.
+    let call = 0
+    vi.mocked(fetchTranslatableResource).mockImplementation(async (_session, rid) => {
+      call += 1
+      if (call <= 6) {
+        // alternate equal/different across pre-flight pairs — make first pair differ to short-circuit pre-flight quickly
+        if (call === 1) {
+          return {
+            resourceId: rid,
+            translatableContent: [],
+            translations: [{key: 'a', value: 'x', locale: 'fr'}],
+          } as TranslatableResource
+        }
+        if (call === 2) {
+          return {resourceId: rid, translatableContent: [], translations: []} as TranslatableResource
+        }
+      }
+      return {resourceId: rid, translatableContent: [], translations: []} as TranslatableResource
+    })
+    vi.mocked(listLiveThemeResourcesWithContent).mockResolvedValue([])
+
+    await mirrorTranslations({password: 'shptka_x', from: 1, to: 2})
+
+    expect(listLiveThemeResourcesWithContent).toHaveBeenCalled()
+    expect(listThemeResources).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/theme/translations.ts
+++ b/src/services/theme/translations.ts
@@ -1,0 +1,332 @@
+import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {outputInfo, outputWarn} from '@shopify/cli-kit/node/output'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {ensureThemeStore} from '../../utilities/shopify/theme-store.js'
+import {getLiveTheme, getOnDeckThemeId} from './deploy.js'
+import {mapWithConcurrency} from '../../utilities/concurrency.js'
+import {
+  fetchTranslatableResource,
+  listLiveThemeResourcesWithContent,
+  listThemeResources,
+  publishedNonPrimaryLocales,
+  registerTranslations,
+  ThemeResourceType,
+  THEME_RESOURCE_TYPES,
+  TranslatableResource,
+} from '../../utilities/translations.js'
+
+export interface MirrorTranslationsFlags {
+  store?: string
+  password?: string
+  from?: number
+  to?: number
+  blue?: number
+  green?: number
+  locale?: string
+  resourceType?: string
+  dryRun?: boolean
+  noColor?: boolean
+  verbose?: boolean
+}
+
+export interface MirrorTranslationsResult {
+  fromThemeId: string
+  toThemeId: string
+  locales: string[]
+  skipped: boolean
+  perLocale: Array<{
+    locale: string
+    resources: number
+    writes: number
+    alreadyInSync: number
+    skippedKeysMissingOnTarget: number
+    skippedResourcesMissingOnTarget: number
+    errors: Array<{code: string | null; field: string[] | null; message: string}>
+  }>
+}
+
+const FETCH_CONCURRENCY = 8
+
+// Resource types whose aggregate translation maps are used by isMirrorNeeded
+// to decide whether the full mirror can be short-circuited. ONLINE_STORE_THEME
+// aggregates section.* translations across the entire theme;
+// ONLINE_STORE_THEME_LOCALE_CONTENT carries `locales/*.json` overrides;
+// ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS carries merchant-edited settings.
+// Together these cover the surfaces Translate & Adapt writes to most often.
+const PRE_FLIGHT_TYPES: ThemeResourceType[] = [
+  'ONLINE_STORE_THEME',
+  'ONLINE_STORE_THEME_LOCALE_CONTENT',
+  'ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS',
+]
+
+// Determines source/target theme IDs for the mirror.
+//
+//   --from / --to       explicit override (used for recovery scenarios where
+//                       the authoritative-translations theme is no longer
+//                       [live] — e.g. a deploy stranded the most recent edits
+//                       on the previously-live color)
+//   --blue / --green    standard recurring use: source = current live theme,
+//                       target = the on-deck (about-to-become-live) theme
+//
+// Anchoring on explicit IDs when provided is intentional: if a deploy slips
+// in between when the operator decided to mirror and when the command runs,
+// the [live] flag may have flipped, and we do NOT want the mirror direction
+// to silently invert and overwrite the freshly-edited theme with stale data.
+export async function resolveThemes(
+  session: AdminSession,
+  flags: MirrorTranslationsFlags,
+): Promise<{fromThemeId: string; toThemeId: string; sourceIsLive: boolean}> {
+  if (flags.from && flags.to) {
+    const liveThemeId = await getLiveTheme(session).catch(() => null)
+    return {
+      fromThemeId: String(flags.from),
+      toThemeId: String(flags.to),
+      sourceIsLive: liveThemeId === flags.from,
+    }
+  }
+  if (flags.from || flags.to) {
+    throw new AbortError('--from and --to must be provided together (or neither, to derive from blue/green).')
+  }
+  if (!flags.blue || !flags.green) {
+    throw new AbortError(
+      'Either provide --from/--to explicitly, or provide --blue and --green (or SKR_FLAG_BLUE_THEME_ID / SKR_FLAG_GREEN_THEME_ID) so the live/on-deck pair can be inferred.',
+    )
+  }
+  const liveThemeId = await getLiveTheme(session)
+  const onDeck = getOnDeckThemeId(liveThemeId, flags.blue, flags.green)
+  return {fromThemeId: String(liveThemeId), toThemeId: String(onDeck.id), sourceIsLive: true}
+}
+
+function swapToTarget(fromResourceId: string, fromThemeId: string, toThemeId: string): string {
+  if (fromResourceId.includes(`theme_id=${fromThemeId}`)) {
+    return fromResourceId.replace(`theme_id=${fromThemeId}`, `theme_id=${toThemeId}`)
+  }
+  if (fromResourceId.endsWith(`/${fromThemeId}`)) {
+    return fromResourceId.slice(0, -fromThemeId.length) + toThemeId
+  }
+  throw new AbortError(`Cannot remap resourceId ${fromResourceId} from theme ${fromThemeId} to ${toThemeId}`)
+}
+
+function translationsEqual(a: TranslatableResource | null, b: TranslatableResource | null): boolean {
+  if (!a || !b) return a === b
+  if (a.translations.length !== b.translations.length) return false
+  const bMap = new Map(b.translations.map((t) => [t.key, t.value]))
+  for (const t of a.translations) {
+    if (bMap.get(t.key) !== t.value) return false
+  }
+  return true
+}
+
+// Cheap pre-flight: compare the aggregate translation maps for a handful of
+// resource types between source and target. If they all match per-locale, the
+// full mirror would be a no-op and we can skip it entirely. ~6 queries vs
+// hundreds for a full inventory.
+//
+// Heuristic, not perfect: in theory a translation could exist on source for a
+// resource type NOT in PRE_FLIGHT_TYPES while these three match. In practice
+// the three pre-flight types cover where Translate & Adapt writes land for
+// the kinds of edits clients actually make. Treat any mismatch as "needs
+// mirror" and only skip when everything matches.
+export async function isMirrorNeeded(
+  session: AdminSession,
+  fromThemeId: string,
+  toThemeId: string,
+  locales: readonly string[],
+): Promise<boolean> {
+  for (const resourceType of PRE_FLIGHT_TYPES) {
+    for (const locale of locales) {
+      // ONLINE_STORE_THEME id is the theme id directly; the other two are
+      // OnlineStoreThemeX/<theme-id>. Build both.
+      const fromRid =
+        resourceType === 'ONLINE_STORE_THEME'
+          ? `gid://shopify/OnlineStoreTheme/${fromThemeId}`
+          : resourceType === 'ONLINE_STORE_THEME_LOCALE_CONTENT'
+            ? `gid://shopify/OnlineStoreThemeLocaleContent/${fromThemeId}`
+            : `gid://shopify/OnlineStoreThemeSettingsDataSections/${fromThemeId}`
+      const toRid = swapToTarget(fromRid, fromThemeId, toThemeId)
+      const [from, to] = await Promise.all([
+        fetchTranslatableResource(session, fromRid, locale),
+        fetchTranslatableResource(session, toRid, locale),
+      ])
+      if (!translationsEqual(from, to)) return true
+    }
+  }
+  return false
+}
+
+async function buildPerLocaleResult(
+  session: AdminSession,
+  fromThemeId: string,
+  toThemeId: string,
+  locale: string,
+  dryRun: boolean,
+  sourceIsLive: boolean,
+  resourceTypeFilter?: ThemeResourceType,
+): Promise<MirrorTranslationsResult['perLocale'][number]> {
+  const result: MirrorTranslationsResult['perLocale'][number] = {
+    locale,
+    resources: 0,
+    writes: 0,
+    alreadyInSync: 0,
+    skippedKeysMissingOnTarget: 0,
+    skippedResourcesMissingOnTarget: 0,
+    errors: [],
+  }
+
+  // When source is the live theme, the type-scoped translatableResources
+  // query already returns content + translations, so we can pull source data
+  // in one paginated walk per type (~7 round-trips total) instead of one
+  // round-trip per resource (~120+).
+  outputInfo(`Inventorying ${locale} translations on source theme ${fromThemeId}...`)
+  let sourceEntries: Array<{resourceType: ThemeResourceType; resourceId: string; resource: TranslatableResource}> = []
+  if (sourceIsLive) {
+    const liveData = await listLiveThemeResourcesWithContent(session, locale, resourceTypeFilter)
+    for (const e of liveData) {
+      // ONLINE_STORE_THEME comes back as one node per theme — keep only ours.
+      if (e.resourceType === 'ONLINE_STORE_THEME') {
+        if (e.resource.resourceId !== `gid://shopify/OnlineStoreTheme/${fromThemeId}`) continue
+      }
+      sourceEntries.push({resourceType: e.resourceType, resourceId: e.resource.resourceId, resource: e.resource})
+    }
+  } else {
+    const ids = await listThemeResources(session, fromThemeId)
+    const filtered = resourceTypeFilter ? ids.filter((r) => r.resourceType === resourceTypeFilter) : ids
+    const fetched = await mapWithConcurrency(filtered, FETCH_CONCURRENCY, async ({resourceType, resourceId}) => {
+      const resource = await fetchTranslatableResource(session, resourceId, locale)
+      return resource ? {resourceType, resourceId, resource} : null
+    })
+    sourceEntries = fetched.filter((e): e is NonNullable<typeof e> => e !== null)
+  }
+
+  // Drop resources with no translations on the source — nothing to write.
+  const candidates = sourceEntries.filter((e) => e.resource.translations.length > 0)
+
+  // Fetch target counterparts in parallel.
+  outputInfo(`Fetching target theme ${toThemeId} resources (${candidates.length})...`)
+  const targets = await mapWithConcurrency(candidates, FETCH_CONCURRENCY, async ({resourceId}) => {
+    const targetResourceId = swapToTarget(resourceId, fromThemeId, toThemeId)
+    const resource = await fetchTranslatableResource(session, targetResourceId, locale)
+    return {targetResourceId, resource}
+  })
+
+  // Diff + register sequentially per resource (registers are per-resource).
+  for (let i = 0; i < candidates.length; i += 1) {
+    const src = candidates[i]!
+    const tgt = targets[i]!
+    if (!tgt.resource) {
+      result.skippedResourcesMissingOnTarget += 1
+      continue
+    }
+    const targetDigests = new Map(tgt.resource.translatableContent.map((c) => [c.key, c.digest]))
+    const targetValues = new Map(tgt.resource.translations.map((t) => [t.key, t.value]))
+
+    const writes = []
+    for (const t of src.resource.translations) {
+      const digest = targetDigests.get(t.key)
+      if (!digest) {
+        result.skippedKeysMissingOnTarget += 1
+        continue
+      }
+      if (targetValues.get(t.key) === t.value) {
+        result.alreadyInSync += 1
+        continue
+      }
+      writes.push({key: t.key, value: t.value, locale, translatableContentDigest: digest})
+    }
+
+    if (writes.length === 0) continue
+    result.resources += 1
+    result.writes += writes.length
+
+    if (dryRun) continue
+
+    const reg = await registerTranslations(session, tgt.targetResourceId, writes)
+    if (reg.errors.length) {
+      outputWarn(
+        `  ${src.resourceType} ${tgt.targetResourceId}: ${reg.errors.length} userError${
+          reg.errors.length === 1 ? '' : 's'
+        }`,
+      )
+      result.errors.push(...reg.errors)
+    }
+  }
+
+  return result
+}
+
+export async function mirrorTranslations(flags: MirrorTranslationsFlags): Promise<MirrorTranslationsResult> {
+  const store = ensureThemeStore({store: flags.store})
+  if (!flags.password) {
+    throw new AbortError(
+      'A Shopify Theme Access password is required. Pass --password or set SHOPIFY_CLI_THEME_TOKEN. The token must come from a Theme Access app whose scopes include read_translations and write_translations.',
+    )
+  }
+  const session = await ensureAuthenticatedThemes(store, flags.password)
+
+  const {fromThemeId, toThemeId, sourceIsLive} = await resolveThemes(session, flags)
+  if (fromThemeId === toThemeId) {
+    throw new AbortError(`Refusing to mirror translations from theme ${fromThemeId} to itself.`)
+  }
+
+  let resourceTypeFilter: ThemeResourceType | undefined
+  if (flags.resourceType) {
+    if (!(THEME_RESOURCE_TYPES as readonly string[]).includes(flags.resourceType)) {
+      throw new AbortError(`Unknown --resource-type ${flags.resourceType}. Allowed: ${THEME_RESOURCE_TYPES.join(', ')}`)
+    }
+    resourceTypeFilter = flags.resourceType as ThemeResourceType
+  }
+
+  const locales = flags.locale ? [flags.locale] : await publishedNonPrimaryLocales(session)
+  if (locales.length === 0) {
+    outputInfo('No non-primary published locales on this store — nothing to mirror.')
+    return {fromThemeId, toThemeId, locales: [], skipped: false, perLocale: []}
+  }
+
+  outputInfo(`Mirroring translations: theme ${fromThemeId} -> theme ${toThemeId}`)
+  outputInfo(
+    `Locales: ${locales.join(', ')}${resourceTypeFilter ? `  (resource type: ${resourceTypeFilter})` : ''}${
+      flags.dryRun ? '  (dry-run)' : ''
+    }`,
+  )
+
+  // Pre-flight: if source and target already match across the aggregate
+  // resource types, skip the full inventory. Only applies when no
+  // --resource-type filter is set (the filter implies a deliberate, targeted
+  // operation that should always run).
+  if (!resourceTypeFilter) {
+    const needed = await isMirrorNeeded(session, fromThemeId, toThemeId, locales)
+    if (!needed) {
+      outputInfo(
+        'Pre-flight check: source and target translations already in sync across aggregate resource types — skipping full mirror.',
+      )
+      return {fromThemeId, toThemeId, locales: [...locales], skipped: true, perLocale: []}
+    }
+  }
+
+  const perLocale: MirrorTranslationsResult['perLocale'] = []
+  for (const locale of locales) {
+    perLocale.push(
+      await buildPerLocaleResult(
+        session,
+        fromThemeId,
+        toThemeId,
+        locale,
+        flags.dryRun ?? false,
+        sourceIsLive,
+        resourceTypeFilter,
+      ),
+    )
+  }
+
+  for (const r of perLocale) {
+    outputInfo(
+      `  ${r.locale}: ${r.writes} write${r.writes === 1 ? '' : 's'} across ${r.resources} resource${
+        r.resources === 1 ? '' : 's'
+      } (${r.alreadyInSync} already in sync, ${r.skippedKeysMissingOnTarget} keys absent on target, ${
+        r.skippedResourcesMissingOnTarget
+      } resources absent on target)`,
+    )
+  }
+
+  return {fromThemeId, toThemeId, locales: [...locales], skipped: false, perLocale}
+}

--- a/src/utilities/concurrency.ts
+++ b/src/utilities/concurrency.ts
@@ -1,0 +1,26 @@
+// Tiny bounded-concurrency map. Avoids pulling in p-limit for one use site.
+// Resolves to the array of results in input order. Rejects on first error.
+export async function mapWithConcurrency<T, U>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<U>,
+): Promise<U[]> {
+  if (concurrency < 1) throw new Error('concurrency must be >= 1')
+  const results: U[] = new Array(items.length)
+  let nextIndex = 0
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex++
+      if (index >= items.length) return
+      results[index] = await fn(items[index]!, index)
+    }
+  }
+
+  const workers: Promise<void>[] = []
+  for (let i = 0; i < Math.min(concurrency, items.length); i += 1) {
+    workers.push(worker())
+  }
+  await Promise.all(workers)
+  return results
+}

--- a/src/utilities/translations.ts
+++ b/src/utilities/translations.ts
@@ -1,0 +1,261 @@
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {adminRequest} from '@shopify/cli-kit/node/api/admin'
+
+// Theme-scoped translatable resource types. Translations registered against
+// these are keyed to a specific theme GID and do not migrate between themes,
+// which is why a blue/green deploy strands them on the previously-live theme
+// unless something explicitly mirrors them across.
+export const THEME_RESOURCE_TYPES = [
+  'ONLINE_STORE_THEME',
+  'ONLINE_STORE_THEME_APP_EMBED',
+  'ONLINE_STORE_THEME_JSON_TEMPLATE',
+  'ONLINE_STORE_THEME_LOCALE_CONTENT',
+  'ONLINE_STORE_THEME_SECTION_GROUP',
+  'ONLINE_STORE_THEME_SETTINGS_CATEGORY',
+  'ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS',
+] as const
+
+export type ThemeResourceType = (typeof THEME_RESOURCE_TYPES)[number]
+
+export interface TranslatableContent {
+  key: string
+  digest: string
+  locale: string
+}
+
+export interface Translation {
+  key: string
+  value: string
+  locale: string
+  outdated?: boolean
+}
+
+export interface TranslatableResource {
+  resourceId: string
+  translatableContent: TranslatableContent[]
+  translations: Translation[]
+}
+
+interface TranslationInput {
+  key: string
+  value: string
+  locale: string
+  translatableContentDigest: string
+}
+
+const LIST_BY_TYPE_IDS = `
+  query Resources($type: TranslatableResourceType!, $cursor: String) {
+    translatableResources(first: 250, after: $cursor, resourceType: $type) {
+      edges { cursor node { resourceId } }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`
+
+// Richer variant — returns content + translations for each resource in the
+// same pagination. Used when the source theme IS the live theme, which lets
+// us skip per-resource source fetches in the standard recurring deploy case.
+const LIST_BY_TYPE_FULL = `
+  query ResourcesFull($type: TranslatableResourceType!, $cursor: String, $locale: String!) {
+    translatableResources(first: 100, after: $cursor, resourceType: $type) {
+      edges {
+        cursor
+        node {
+          resourceId
+          translatableContent { key digest locale }
+          translations(locale: $locale) { key value locale outdated }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`
+
+const FETCH_ONE = `
+  query Resource($id: ID!, $locale: String!) {
+    translatableResource(resourceId: $id) {
+      resourceId
+      translatableContent { key digest locale }
+      translations(locale: $locale) { key value locale outdated }
+    }
+  }
+`
+
+const REGISTER = `
+  mutation Register($resourceId: ID!, $translations: [TranslationInput!]!) {
+    translationsRegister(resourceId: $resourceId, translations: $translations) {
+      userErrors { field message code }
+      translations { key value locale }
+    }
+  }
+`
+
+const SHOP_LOCALES = `
+  query { shopLocales { locale primary published } }
+`
+
+export async function publishedNonPrimaryLocales(session: AdminSession): Promise<string[]> {
+  const data = await adminRequest<{shopLocales: Array<{locale: string; primary: boolean; published: boolean}>}>(
+    SHOP_LOCALES,
+    session,
+  )
+  return data.shopLocales.filter((l) => l.published && !l.primary).map((l) => l.locale)
+}
+
+// Resource IDs come in two shapes:
+//   gid://shopify/OnlineStoreTheme/<id>                       (theme metadata)
+//   gid://shopify/OnlineStoreThemeLocaleContent/<id>          (path-embedded)
+//   gid://shopify/OnlineStoreThemeSettingsDataSections/<id>   (path-embedded)
+//   gid://shopify/OnlineStoreThemeJsonTemplate/<x>?theme_id=<id>   (query-param)
+//   gid://shopify/OnlineStoreThemeSectionGroup/<x>?theme_id=<id>   (query-param)
+//   gid://shopify/OnlineStoreThemeSettingsCategory/<x>?theme_id=<id>&first_setting_id=<...>
+//   gid://shopify/OnlineStoreThemeAppEmbed/<x>?theme_id=<id>       (query-param)
+export function swapThemeIdInResourceId(rid: string, fromId: string, toId: string): string {
+  if (rid.includes(`theme_id=${fromId}`)) {
+    return rid.replace(`theme_id=${fromId}`, `theme_id=${toId}`)
+  }
+  if (rid.endsWith(`/${fromId}`)) {
+    return rid.slice(0, -fromId.length) + toId
+  }
+  throw new Error(`Cannot remap resourceId ${rid} from theme ${fromId} to ${toId}`)
+}
+
+export function extractThemeIdFromResourceId(rid: string): string | null {
+  const q = rid.match(/theme_id=(\d+)/)
+  if (q) return q[1]!
+  const p = rid.match(/^gid:\/\/shopify\/OnlineStoreTheme(?:LocaleContent|SettingsDataSections)?\/(\d+)$/)
+  if (p) return p[1]!
+  return null
+}
+
+// Enumerates the universe of theme-scoped translatable resource IDs for the
+// given theme. We list via `translatableResources(resourceType: ...)` (which
+// returns the LIVE theme's resources) and swap the embedded theme_id to the
+// requested theme so we can address resources on either color regardless of
+// which is currently published.
+interface ListByTypeIdsResponse {
+  translatableResources: {
+    edges: Array<{cursor: string; node: {resourceId: string}}>
+    pageInfo: {hasNextPage: boolean; endCursor: string | null}
+  }
+}
+
+interface ListByTypeFullResponse {
+  translatableResources: {
+    edges: Array<{
+      cursor: string
+      node: {
+        resourceId: string
+        translatableContent: TranslatableContent[]
+        translations: Translation[]
+      }
+    }>
+    pageInfo: {hasNextPage: boolean; endCursor: string | null}
+  }
+}
+
+export async function listThemeResources(
+  session: AdminSession,
+  themeId: string,
+): Promise<Array<{resourceType: ThemeResourceType; resourceId: string}>> {
+  const out: Array<{resourceType: ThemeResourceType; resourceId: string}> = []
+  for (const resourceType of THEME_RESOURCE_TYPES) {
+    let cursor: string | null = null
+    const rids = new Set<string>()
+    while (true) {
+      const data: ListByTypeIdsResponse = await adminRequest<ListByTypeIdsResponse>(LIST_BY_TYPE_IDS, session, {
+        type: resourceType,
+        cursor,
+      })
+      for (const e of data.translatableResources.edges) {
+        const liveThemeId = extractThemeIdFromResourceId(e.node.resourceId)
+        if (!liveThemeId) continue
+        try {
+          rids.add(swapThemeIdInResourceId(e.node.resourceId, liveThemeId, themeId))
+        } catch {
+          // unmappable IDs (shouldn't happen for known types) — skip
+        }
+      }
+      if (!data.translatableResources.pageInfo.hasNextPage) break
+      cursor = data.translatableResources.pageInfo.endCursor
+    }
+    // ONLINE_STORE_THEME returns every theme in the shop, not just the live one,
+    // so the enumeration above yields one entry per theme. Constrain to the
+    // requested theme directly.
+    if (resourceType === 'ONLINE_STORE_THEME') {
+      rids.clear()
+      rids.add(`gid://shopify/OnlineStoreTheme/${themeId}`)
+    }
+    for (const resourceId of rids) {
+      out.push({resourceType, resourceId})
+    }
+  }
+  return out
+}
+
+// Pulls full content + translations for every theme-scoped resource on the
+// LIVE theme in one paginated walk per resource type. Used when source = live;
+// avoids a per-resource source-fetch round-trip.
+export async function listLiveThemeResourcesWithContent(
+  session: AdminSession,
+  locale: string,
+  filterType?: ThemeResourceType,
+): Promise<Array<{resourceType: ThemeResourceType; resource: TranslatableResource}>> {
+  const out: Array<{resourceType: ThemeResourceType; resource: TranslatableResource}> = []
+  const types = filterType ? [filterType] : THEME_RESOURCE_TYPES
+  for (const resourceType of types) {
+    let cursor: string | null = null
+    while (true) {
+      const data: ListByTypeFullResponse = await adminRequest<ListByTypeFullResponse>(LIST_BY_TYPE_FULL, session, {
+        type: resourceType,
+        cursor,
+        locale,
+      })
+      for (const e of data.translatableResources.edges) {
+        out.push({resourceType, resource: e.node})
+      }
+      if (!data.translatableResources.pageInfo.hasNextPage) break
+      cursor = data.translatableResources.pageInfo.endCursor
+    }
+  }
+  return out
+}
+
+export async function fetchTranslatableResource(
+  session: AdminSession,
+  resourceId: string,
+  locale: string,
+): Promise<TranslatableResource | null> {
+  const data = await adminRequest<{translatableResource: TranslatableResource | null}>(FETCH_ONE, session, {
+    id: resourceId,
+    locale,
+  })
+  return data.translatableResource
+}
+
+const REGISTER_BATCH_SIZE = 100
+
+export async function registerTranslations(
+  session: AdminSession,
+  resourceId: string,
+  translations: TranslationInput[],
+): Promise<{written: number; errors: Array<{code: string | null; field: string[] | null; message: string}>}> {
+  let written = 0
+  const errors: Array<{code: string | null; field: string[] | null; message: string}> = []
+  for (let i = 0; i < translations.length; i += REGISTER_BATCH_SIZE) {
+    const chunk = translations.slice(i, i + REGISTER_BATCH_SIZE)
+    const data = await adminRequest<{
+      translationsRegister: {
+        userErrors: Array<{code: string | null; field: string[] | null; message: string}>
+        translations: Array<{key: string; value: string; locale: string}>
+      }
+    }>(REGISTER, session, {resourceId, translations: chunk})
+    const userErrors = data.translationsRegister.userErrors ?? []
+    if (userErrors.length) {
+      errors.push(...userErrors)
+    } else {
+      written += chunk.length
+    }
+  }
+  return {written, errors}
+}


### PR DESCRIPTION
## Summary

Translations registered via Translate & Adapt (and any caller of `translationsRegister`) for the `ONLINE_STORE_THEME_*` resource types are keyed to a specific theme GID. Blue and Green are distinct permanent themes, so translations written against the currently-live color **do not follow** when the on-deck color is promoted — they're silently stranded, and the storefront falls back to source-language strings.

This came up on Hiya: a fr-CA audit producing hundreds of Translate & Adapt edits on the live theme disappeared after the next blue/green promotion. Recovery required a one-off Blue→Green `translationsRegister` mirror. This PR makes that mirror a first-class shopkeeper concept.

## Changes

**New command** — `shopkeeper theme translations mirror`
- `--from <id>` / `--to <id>` — explicit override for recovery scenarios where the freshest translation set lives on a no-longer-live theme. Anchoring on IDs intentionally prevents direction-inversion if a deploy slips in between operator decision and command run.
- `--blue <id>` / `--green <id>` — derive `source = live`, `target = on-deck` via the same `getLiveTheme` + `getOnDeckThemeId` helpers `theme deploy` uses.
- `--locale <code>` — restrict to a single locale; default is every published non-primary locale.
- `--resource-type <type>` — restrict to one of the seven `ONLINE_STORE_THEME_*` types. Useful for targeted ops and CI smoke tests.
- `--dry-run` — build the write plan and print summary without invoking `translationsRegister`.

**Optional auto-step inside `blueGreenDeploy()`** — opt-in
- Gated on `--mirror-translations` (env: `SKR_FLAG_MIRROR_TRANSLATIONS`). Default-off; most stores don't use Translate & Adapt and paying the pre-flight cost on every deploy isn't justified for them.
- Mirror failures are logged as warnings — they don't abort the code deploy.

## Performance

The naive implementation (one query to enumerate + one source fetch + one target fetch per resource, serially) ran ~5 minutes on Hiya's catalog. Three optimizations bring it well under a minute:

1. **Pre-flight short-circuit.** Before the full inventory, compare aggregate translation maps for `ONLINE_STORE_THEME`, `ONLINE_STORE_THEME_LOCALE_CONTENT`, and `ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS` between source and target. If all match per-locale, skip the mirror entirely (~6 queries vs ~250). Heuristic — documented as such in code.
2. **Source-is-live fast path.** When source = live, the type-scoped `translatableResources` query returns content + translations directly in pagination, avoiding a per-resource source-fetch round-trip. Halves source reads for the recurring case.
3. **Bounded-concurrency parallelism.** Per-resource target fetches go 8-wide. Hand-rolled `mapWithConcurrency` in `src/utilities/concurrency.ts` (no new deps).

## Auth

Requires a Shopify Theme Access password (`--password` or `SHOPIFY_CLI_THEME_TOKEN`). The token's Theme Access app must include `read_translations` + `write_translations` scopes. No OAuth fallback — `AbortError` with a clear message if password is missing. Matches shopkeeper's existing baseline that all commands assume a password.

## Resource scope

```
ONLINE_STORE_THEME
ONLINE_STORE_THEME_APP_EMBED
ONLINE_STORE_THEME_JSON_TEMPLATE
ONLINE_STORE_THEME_LOCALE_CONTENT
ONLINE_STORE_THEME_SECTION_GROUP
ONLINE_STORE_THEME_SETTINGS_CATEGORY
ONLINE_STORE_THEME_SETTINGS_DATA_SECTIONS
```

Resource-scoped translations (PRODUCT, COLLECTION, METAOBJECT, PAGE, …) are not theme-keyed and survive blue/green without intervention, so they're intentionally excluded.

## Idempotence + safety

- Skips writes when the target value already matches the source.
- Skips keys whose source content has been removed on the target, or whose digest no longer matches (template-shape drift between deploys).
- Refuses to mirror a theme onto itself.
- Source/target anchored on explicit IDs when provided — never re-resolves `[live]` mid-script, so a deploy slipping in between decision and execution cannot invert direction.

## Tests

164 tests passing, 17 new in `services/theme/translations.test.ts`:
- `resolveThemes` flag matrix incl. `sourceIsLive` detection
- password requirement
- registration-with-digest-match
- idempotent same-value skip
- dry-run
- target-resource-absent
- locale + resource-type filters
- pre-flight skip when source and target match
- full-mirror-on-pre-flight-mismatch
- live-source fast path uses `listLiveThemeResourcesWithContent`

`services/theme/deploy.test.ts` updated: default deploys do not mirror; explicit `mirrorTranslations: true` invokes the mirror; mirror failures don't block the code deploy.

## Note on the docs diff

`bin/generate-readme.sh` regenerates `docs/commands/readme.md` from the oclif manifest. Running it picked up env-annotation drift from earlier commands that hadn't regenerated since their last flag change. Doc churn outside the `theme translations mirror` section is unrelated to this PR but kept in since the script is the documented way to regenerate.